### PR TITLE
v1.6.5 release candidate

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -100,7 +100,6 @@ BUILD_TIME := $(shell date +%Y%m%d%H%M%S)
 export BUILD_STRING = $(PROJECT): Vivado v$(VIVADO_VERSION), $(BUILD_SYS_NAME) ($(BUILD_SVR_TYPE)), Built $(BUILD_DATE) by $(BUILD_USER)
 
 # Check the GIT status
-export GIT_DIFF   = $(shell git diff)
 export GIT_STATUS = $(shell git diff-index --name-only HEAD)
 
 # Check for non-dirty git clone

--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -828,7 +828,7 @@ proc CheckGitVersion { } {
    ######################################
    # Define the git/git-lfs version locks
    ######################################
-   set gitLockTag    {2.13.0}
+   set gitLockTag    {2.9.0}
    set gitLfsLockTag {2.1.1}
    ######################################
    

--- a/vivado_wis.tcl
+++ b/vivado_wis.tcl
@@ -49,7 +49,6 @@ lappend linuxVars "RECONFIG_PBLOCK"
 
 # Set GIT variables
 lappend linuxVars "GIT_BYPASS"
-lappend linuxVars "GIT_DIFF"
 lappend linuxVars "GIT_STATUS"
 lappend linuxVars "GIT_TAG_NAME"
 lappend linuxVars "GIT_HASH_LONG"


### PR DESCRIPTION
### Description
In CheckGitVersion, reducing version check to v2.9.0
removing export GIT_DIFF in system_vivado.mk

### JIRA
[ESROGUE-229](https://jira.slac.stanford.edu/browse/ESROGUE-229)
[ESROGUE-230](https://jira.slac.stanford.edu/browse/ESROGUE-230)