### PR TITLE
Switch to a different RemoveUnusedCode routine

### DIFF
--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -375,20 +375,20 @@ proc RemoveUnsuedCode { } {
    ## This should work but cause DRC errors in impl_1
    #######################################################
    # # Get all used synthesis files 
-   # set syn_list  [get_files -compile_order sources -used_in synthesis]
+   set syn_list  [get_files -compile_order sources -used_in synthesis]
    # # Get all used simulation files 
-   # set sim_list  [get_files -compile_order sources -used_in simulation]
+   set sim_list  [get_files -compile_order sources -used_in simulation]
    # # Combine the list together synthesis & simulation 
-   # set file_list "${syn_list} ${sim_list}"
+   set file_list "${syn_list} ${sim_list}"
    # # Find all the files not in 
-   # set diff_list [ListComp ${file_list} [get_files]]
+   set diff_list [ListComp ${file_list} [get_files]]
    # # Remove the unused files
-   # remove_files [get_files ${diff_list}]
+   remove_files [get_files ${diff_list}]
    
    ###################################################
    # Only workes with synthesis files (not simulation)
    ###################################################
-   remove_files [get_files -filter {IS_AUTO_DISABLED}]
+   #remove_files [get_files -filter {IS_AUTO_DISABLED}]
    ###################################################   
 }
 


### PR DESCRIPTION
Xilinx deprecated the IS_AUTO_DISABLED property, so the method we were using no longer works.

The comments note that this way causes DRC errors. I'm running a test build now to see if I find any.