### PR TITLE
vivado_vcs.tcl update

### DIFF
--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -302,7 +302,7 @@ proc CopyBdCoresDebug { } {
 # Generate Verilog simulation models for all .DCP files in the source tree
 proc DcpToVerilogSim { } {
    source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
-   foreach filePntr [get_files {*.dcp}] {
+   foreach filePntr [get_files -compile_order sources -used_in simulation -filter {FILE_TYPE == DCP}] {
       if { [file extension ${filePntr}] == ".dcp" } {
          ## Open the check point
          open_checkpoint ${filePntr}     
@@ -370,26 +370,9 @@ proc CreatePyRogueTarGz { } {
 
 # Remove unused code   
 proc RemoveUnsuedCode { } {
-   
-   #######################################################
-   ## This should work but cause DRC errors in impl_1
-   #######################################################
-   # # Get all used synthesis files 
-   # set syn_list  [get_files -compile_order sources -used_in synthesis]
-   # # Get all used simulation files 
-   # set sim_list  [get_files -compile_order sources -used_in simulation]
-   # # Combine the list together synthesis & simulation 
-   # set file_list "${syn_list} ${sim_list}"
-   # # Find all the files not in 
-   # set diff_list [ListComp ${file_list} [get_files]]
-   # # Remove the unused files
-   # remove_files [get_files ${diff_list}]
-   
-   ###################################################
-   # Only workes with synthesis files (not simulation)
-   ###################################################
+   update_compile_order -quiet -fileset sources_1
+   update_compile_order -quiet -fileset sim_1
    remove_files [get_files -filter {IS_AUTO_DISABLED}]
-   ###################################################   
 }
 
 # GIT Build TAG   
@@ -732,13 +715,15 @@ proc CheckImpl { {flags ""} } {
    }
    return false   
 }
-proc VcsCompleteMessage {dirPath sharedMem} {
+proc VcsCompleteMessage {dirPath rogueSim} {
    puts "\n\n********************************************************"
    puts "The VCS simulation script has been generated."
    puts "To compile and run the simulation:"
    puts "\t\$ cd ${dirPath}/"    
    puts "\t\$ ./sim_vcs_mx.sh"
-   puts "\t\$ source setup_env.csh"
+   if { ${rogueSim} == true } {
+      puts "\t\$ source setup_env.csh"
+   }
    puts "\t\$ ./simv"   
    puts "********************************************************\n\n" 
 }

--- a/vivado_sources.tcl
+++ b/vivado_sources.tcl
@@ -154,8 +154,6 @@ SourceTclFile ${VIVADO_DIR}/sources.tcl
 
 # Remove all unused code
 if { $::env(REMOVE_UNUSED_CODE) != 0 } {
-   update_compile_order -quiet -fileset sources_1
-   update_compile_order -quiet -fileset sim_1
    RemoveUnsuedCode
 }
 

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -17,7 +17,7 @@ proc VcsVersionCheck { } {
    set supported "M-2017.03"
    
    # Get the VCS version
-   set git_rc [catch {
+   set err_ret [catch {
       exec vcs -ID | grep version
    } grepVersion]
    scan $grepVersion "vcs script version : %s\n%s" VersionNumber blowoff
@@ -137,7 +137,22 @@ if { ${rogueSimPath} != "" } {
 
    # Set the flag true
    set rogueSimEn true 
-
+   
+   # Check the zeromq library exists and its version
+   set err_ret [catch {exec pkg-config --exists {libzmq >= 4.2.0} --print-errors} libzmq]   
+   if { ${libzmq} != "" } {
+      puts "\n\n\n\n\n********************************************************"      
+      if { [string match "*Package libzmq was not found*" ${libzmq}] == 1 } {
+         puts "libzmq package was not found"
+         puts "Please make sure that you have libzmq installed"
+         puts "or have sourced the necessary rogue setup scripts"
+      } else {
+         puts ${libzmq}
+      }
+      puts "********************************************************\n\n\n\n\n"
+      exit -1   
+   }
+   
    # Create the setup environment script: C-SHELL
    set envScript [open ${simTbOutDir}/setup_env.csh  w]
    puts  ${envScript} "limit stacksize 60000"

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -80,6 +80,7 @@ if { [file exists ${simLibOutDir}] != 1 } {
    # Configure Vivado to generate the VCS scripts
    set_property target_simulator "VCS" [current_project]
    set_property compxlib.vcs_compiled_library_dir ${simLibOutDir} [current_project]   
+   set_property nl.process_corner fast [get_filesets sim_1]   
    
    ##################################################################
    ##                synopsys_sim.setup bug fix

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -116,9 +116,6 @@ if { [file exists ${simLibOutDir}] != 1 } {
 ## Export the Simulation
 #####################################################################################################  
 
-# Generate Verilog simulation models for all .DCP files in the simulation tree
-DcpToVerilogSim
-
 # Update the compile order
 update_compile_order -quiet -fileset sim_1
 

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -88,7 +88,9 @@ export_ip_user_files -no_script
 update_compile_order -quiet -fileset sim_1
 
 # Launch the scripts generator 
-export_simulation -absolute_path -force -simulator vcs -lib_map_path ${simLibOutDir} -directory ${simTbOutDir}/   
+set include [get_property include_dirs   [get_filesets sim_1]]; # Verilog only
+set define  [get_property verilog_define [get_filesets sim_1]]; # Verilog only
+export_simulation -absolute_path -force -simulator vcs -include ${include} -define ${define} -lib_map_path ${simLibOutDir} -directory ${simTbOutDir}/   
 
 #####################################################################################################
 ## Build the simlink directory (required for softrware co-simulation)

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -187,7 +187,7 @@ if { ${rogueSimPath} != "" } {
    exec make clean
 
    # Move back to simulation target directory
-   cd $::DIR_PATH
+   cd $::env(PROJ_DIR)
 
 }
 


### PR DESCRIPTION
### Description
- added Verilog include/define support
- added VCS version checking
- fixed bug with VHDL only simulations
- added zeromq checking for rogue sim
- added auto-detection of RogueSim.vhd (symbol link no longer required)