### PR TITLE
Additional features for HLS projects

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -40,10 +40,6 @@ ifndef PARALLEL_SYNTH
 export PARALLEL_SYNTH = 1
 endif
 
-ifndef HLS_SIM_TOOL
-export HLS_SIM_TOOL = vcs
-endif
-
 ifndef GIT_BYPASS
 export GIT_BYPASS = 1
 endif

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -40,6 +40,10 @@ ifndef PARALLEL_SYNTH
 export PARALLEL_SYNTH = 1
 endif
 
+ifndef HLS_SIM_TOOL
+export HLS_SIM_TOOL = vcs
+endif
+
 ifndef GIT_BYPASS
 export GIT_BYPASS = 1
 endif

--- a/system_vivado_hls.mk
+++ b/system_vivado_hls.mk
@@ -98,16 +98,16 @@ $(SOURCE_DEPEND) : $(SRC_FILE) $(VIVADO_DEPEND)
 ###############################################################
 #### Vivado Batch without design export  ######################
 ###############################################################
-.PHONY : hls
-hls : $(SOURCE_DEPEND)
+.PHONY : csyn
+csyn : $(SOURCE_DEPEND)
 	$(call ACTION_HEADER,"Vivado HLS Build without design export")
 	@cd $(OUT_DIR); export SKIP_EXPORT=1; vivado_hls -f $(RUCKUS_DIR)/vivado_hls_build.tcl;
 
 ######################################################################################
 #### Vivado Batch without co-simulation and without design export ####################
 ######################################################################################
-.PHONY : hls_fast
-hls_fast : $(SOURCE_DEPEND)
+.PHONY : csyn_nocosim
+csyn_nocosim : $(SOURCE_DEPEND)
 	$(call ACTION_HEADER,"Vivado HLS Build without co-simulation and without design export")
 	@cd $(OUT_DIR); export FAST_DCP_GEN=1; export SKIP_EXPORT=1; vivado_hls -f $(RUCKUS_DIR)/vivado_hls_build.tcl;
 
@@ -122,8 +122,8 @@ dcp : $(SOURCE_DEPEND)
 ###############################################################
 #### Vivado Batch without co-simulation #######################
 ###############################################################
-.PHONY : dcp_fast
-dcp_fast : $(SOURCE_DEPEND)
+.PHONY : dcp_nocosim
+dcp_nocosim : $(SOURCE_DEPEND)
 	$(call ACTION_HEADER,"Vivado HLS Build without co-simulation")
 	@cd $(OUT_DIR); export FAST_DCP_GEN=1; vivado_hls -f $(RUCKUS_DIR)/vivado_hls_build.tcl; vivado -mode batch -source $(RUCKUS_DIR)/vivado_hls_dcp.tcl
 

--- a/system_vivado_hls.mk
+++ b/system_vivado_hls.mk
@@ -28,6 +28,12 @@ export RTL_DIR = $(abspath $(PROJ_DIR)/rtl)
 # Source Files
 export SRC_FILE = $(PROJ_DIR)/sources.tcl
 
+# HLS Simulation Tool [vcs, xsim, modelsim, ncsim, riviera]
+ifndef HLS_SIM_TOOL
+export HLS_SIM_TOOL = vcs
+endif
+
+
 define ACTION_HEADER
 @echo 
 @echo    ================================================================

--- a/system_vivado_hls.mk
+++ b/system_vivado_hls.mk
@@ -90,6 +90,22 @@ $(SOURCE_DEPEND) : $(SRC_FILE) $(VIVADO_DEPEND)
 	@cd $(OUT_DIR); vivado_hls -f $(RUCKUS_DIR)/vivado_hls_sources.tcl
 
 ###############################################################
+#### Vivado Batch without design export  ######################
+###############################################################
+.PHONY : hls
+hls : $(SOURCE_DEPEND)
+	$(call ACTION_HEADER,"Vivado HLS Build without design export")
+	@cd $(OUT_DIR); export SKIP_EXPORT=1; vivado_hls -f $(RUCKUS_DIR)/vivado_hls_build.tcl;
+
+######################################################################################
+#### Vivado Batch without co-simulation and without design export ####################
+######################################################################################
+.PHONY : hls_fast
+hls_fast : $(SOURCE_DEPEND)
+	$(call ACTION_HEADER,"Vivado HLS Build without co-simulation and without design export")
+	@cd $(OUT_DIR); export FAST_DCP_GEN=1; export SKIP_EXPORT=1; vivado_hls -f $(RUCKUS_DIR)/vivado_hls_build.tcl;
+
+###############################################################
 #### Vivado Batch #############################################
 ###############################################################
 .PHONY : dcp

--- a/vivado_hls_build.tcl
+++ b/vivado_hls_build.tcl
@@ -38,6 +38,9 @@ if { [file isdirectory ${PROJ_DIR}/ip/] != 1 } {
    exec mkdir ${PROJ_DIR}/ip/
 }
 
+# Copy the HLS csynth report
+exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/syn/report/*.rpt"]] ${PROJ_DIR}/ip/.
+
 # Export the Design
 if { [info exists ::env(SKIP_EXPORT)] == 0 } {
    export_design -flow syn -rtl verilog -format ip_catalog

--- a/vivado_hls_build.tcl
+++ b/vivado_hls_build.tcl
@@ -39,21 +39,23 @@ if { [file isdirectory ${PROJ_DIR}/ip/] != 1 } {
 }
 
 # Export the Design
-export_design -flow syn -rtl verilog -format ip_catalog
+if { [info exists ::env(SKIP_EXPORT)] == 0 } {
+   export_design -flow syn -rtl verilog -format ip_catalog
 
 # Copy over the .DCP file
-exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/verilog/project.runs/synth_1/*.dcp"]] ${PROJ_DIR}/ip/.
+   exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/verilog/project.runs/synth_1/*.dcp"]] ${PROJ_DIR}/ip/.
 
 # Copy the driver to module source tree
-set DRIVER ${OUT_DIR}/${PROJECT}_project/solution1/impl/ip/drivers
-if { [file exist  ${DRIVER}] } {
-   set DRIVER ${DRIVER}/[exec ls ${DRIVER}]/src
-   set DRIVER [glob ${DRIVER}/*_hw.h]
-   exec cp -f ${DRIVER} ${PROJ_DIR}/ip/.
-}
+   set DRIVER ${OUT_DIR}/${PROJECT}_project/solution1/impl/ip/drivers
+   if { [file exist  ${DRIVER}] } {
+      set DRIVER ${DRIVER}/[exec ls ${DRIVER}]/src
+      set DRIVER [glob ${DRIVER}/*_hw.h]
+      exec cp -f ${DRIVER} ${PROJ_DIR}/ip/.
+   }   
 
 # Copy the HLS report
-exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/report/verilog/*.rpt"]] ${PROJ_DIR}/ip/.
+   exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/report/verilog/*.rpt"]] ${PROJ_DIR}/ip/.
+}
 
 # Close current solution
 close_solution

--- a/vivado_hls_build.tcl
+++ b/vivado_hls_build.tcl
@@ -45,10 +45,10 @@ exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/syn/report/*
 if { [info exists ::env(SKIP_EXPORT)] == 0 } {
    export_design -flow syn -rtl verilog -format ip_catalog
 
-# Copy over the .DCP file
+   # Copy over the .DCP file
    exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/verilog/project.runs/synth_1/*.dcp"]] ${PROJ_DIR}/ip/.
 
-# Copy the driver to module source tree
+   # Copy the driver to module source tree
    set DRIVER ${OUT_DIR}/${PROJECT}_project/solution1/impl/ip/drivers
    if { [file exist  ${DRIVER}] } {
       set DRIVER ${DRIVER}/[exec ls ${DRIVER}]/src
@@ -56,7 +56,7 @@ if { [info exists ::env(SKIP_EXPORT)] == 0 } {
       exec cp -f ${DRIVER} ${PROJ_DIR}/ip/.
    }   
 
-# Copy the HLS report
+   # Copy the HLS implementation report
    exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/impl/report/verilog/*.rpt"]] ${PROJ_DIR}/ip/.
 }
 

--- a/vivado_hls_build.tcl
+++ b/vivado_hls_build.tcl
@@ -30,7 +30,7 @@ csynth_design
 
 # Run co-simulation (compares the C/C++ code to the RTL)
 if { [info exists ::env(FAST_DCP_GEN)] == 0 } {
-   cosim_design -O -ldflags ${LDFLAGS} -argv ${ARGV} -trace_level all -rtl verilog -tool vcs
+   cosim_design -O -ldflags ${LDFLAGS} -argv ${ARGV} -trace_level all -rtl verilog -tool $::env(HLS_SIM_TOOL)
 }
 
 # Copy the IP directory to module source tree


### PR DESCRIPTION
### Description

3 proposed changes in this pull request:

**1)  Allow building only HLS project through csynth, skipping design export.**

Introduced two additional make targets, hls and hls_fast. One can play with the
HLS algo first and inspect csynth report first before proceeding with full design export.

**2)  Copy HLS csynth report to ip/ directory**

**3) Set HLS Simulation Tool in top Makefile. (the change is backward compatible, with vcs set as default ).**

One can override VCS as the default HLS simulation tool and specify any simulator supported by Vivado HLS. This can be achieved by exporting HLS_SIM_TOOL variable in user's Makefile.

e.g. Vivado Simualtor
export HLS_SIM_TOOL = xsim


