### PR TITLE
Fix broken command to copy C synth reports to ip/ directory.

### DIFF
--- a/vivado_hls_build.tcl
+++ b/vivado_hls_build.tcl
@@ -38,8 +38,9 @@ if { [file isdirectory ${PROJ_DIR}/ip/] != 1 } {
    exec mkdir ${PROJ_DIR}/ip/
 }
 
-# Copy the HLS csynth report
-exec cp -f  [exec ls [glob "${OUT_DIR}/${PROJECT}_project/solution1/syn/report/*.rpt"]] ${PROJ_DIR}/ip/.
+# Copy the HLS csynth reports
+set csyn_reports [glob "${OUT_DIR}/${PROJECT}_project/solution1/syn/report/*.rpt"]
+file copy -force {*}$csyn_reports ${PROJ_DIR}/ip/.
 
 # Export the Design
 if { [info exists ::env(SKIP_EXPORT)] == 0 } {


### PR DESCRIPTION
Previous command was able to copy only a single *.rpt file to target directory and
threw an error if more than one *.rpt file was found in the source directory.