### PR TITLE
Avoid placing an extra '0' on the end of the githash in the filename

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -42,7 +42,7 @@ endif
 
 ifndef RECONFIG_CHECKPOINT
 export RECONFIG_CHECKPOINT = 0
-export RECONFIG_STATIC_HASH = 0
+export RECONFIG_STATIC_HASH = ""
 else
 export RECONFIG_STATIC_FILE = $(notdir $(RECONFIG_CHECKPOINT))
 export RECONFIG_STATIC_HASH = -$(shell echo '$(RECONFIG_STATIC_FILE)' | awk -F'-' '{print $$5}' )


### PR DESCRIPTION
### Description
- Avoid placing an extra '0' on the end of the githash in the filename