### PR TITLE
v1.8.1 release candidate

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -50,7 +50,7 @@ endif
 
 ifndef RECONFIG_CHECKPOINT
 export RECONFIG_CHECKPOINT = 0
-export RECONFIG_STATIC_HASH = 0
+export RECONFIG_STATIC_HASH = ""
 else
 export RECONFIG_STATIC_FILE = $(notdir $(RECONFIG_CHECKPOINT))
 export RECONFIG_STATIC_HASH = -$(shell echo '$(RECONFIG_STATIC_FILE)' | awk -F'-' '{print $$5}' )

--- a/vivado_build.tcl
+++ b/vivado_build.tcl
@@ -167,7 +167,7 @@ source ${RUCKUS_DIR}/vivado_post_route.tcl
 ########################################################
 ## Export static checkpoint for dynamic partial reconfiguration build
 ########################################################
-if { [expr { ${VIVADO_VERSION} >= 2016.4 }] } {
+if { [VersionCompare 2016.4] >= 0 } {
    if { [get_property PR_FLOW [current_project]] != 0 } {
       ExportStaticReconfigDcp
    }

--- a/vivado_gui.tcl
+++ b/vivado_gui.tcl
@@ -18,3 +18,4 @@ source -quiet $::env(RUCKUS_DIR)/vivado_proc.tcl
 source -quiet $::env(RUCKUS_DIR)/vivado_properties.tcl
 source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl
 set_property STEPS.WRITE_BITSTREAM.TCL.POST ${RUCKUS_DIR}/vivado_post_route_run.tcl [get_runs impl_1]
+SourceTclFile ${VIVADO_DIR}/gui.tcl

--- a/vivado_messages.tcl
+++ b/vivado_messages.tcl
@@ -63,7 +63,7 @@ set_msg_config -suppress -id {DRC REQP-52};   # DRC: connects_GTGREFCLK_ACTIVE
 set_msg_config -suppress -id {BD 41-434}; # Block Design: Could not find an IP with XCI file by name
 
 ## Check for version 2015.3 (or older)
-if { [expr { ${VIVADO_VERSION} <= 2015.3 }] } {
+if { [VersionCompare 2015.3] <= 0 } {
    set_msg_config -suppress -id {Synth 8-637}; # SYNTH: synthesizing blackbox instance .... [required for upgrading {Synth 8-63} to an ERROR]
    set_msg_config -suppress -id {Synth 8-638}; # SYNTH: synthesizing module .... [required for upgrading {Synth 8-63} to an ERROR]
 }
@@ -108,7 +108,7 @@ set_msg_config -id {Synth 8-327}  -new_severity ERROR;# SYNTH: Inferred latch
 set_msg_config -id {VRFC 10-664}  -new_severity ERROR;# SIM:   expression has XXX elements ; expected XXX
 
 ## Check for version 2015.3 (or older)
-if { [expr { ${VIVADO_VERSION} <= 2015.3 }] } {
+if { [VersionCompare 2015.3] <= 0 } {
    set_msg_config -id {Synth 8-63}   -new_severity ERROR;# SYNTH: RTL assertion
 }
 

--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -455,7 +455,8 @@ proc CheckWritePermission { } {
 ## Check for unsupported versions that ruckus does NOT support (https://confluence.slac.stanford.edu/x/n4-jCg)
 proc CheckVivadoVersion { } {
    # Check for unsupported versions of ruckus
-   if { [expr { $::env(VIVADO_VERSION) == 2017.1 }] || [expr { $::env(VIVADO_VERSION) < 2014.1 }]} {
+   if { [VersionCompare 2017.1] == 0 ||
+        [VersionCompare 2014.1] < 0 } {
       puts "\n\n\n\n\n********************************************************"
       puts "ruckus does NOT support Vivado $::env(VIVADO_VERSION)"
       puts "https://confluence.slac.stanford.edu/x/n4-jCg"
@@ -463,7 +464,7 @@ proc CheckVivadoVersion { } {
       return -code error
    }
    # Check if version is newer than what official been tested
-   if { [expr { $::env(VIVADO_VERSION) > 2019.1 }] } {
+   if { [VersionCompare 2019.1.3] > 0 } {
       puts "\n\n\n\n\n********************************************************"
       puts "ruckus has NOT been regression tested with this Vivado $::env(VIVADO_VERSION) release yet"
       puts "https://confluence.slac.stanford.edu/x/n4-jCg"
@@ -565,7 +566,7 @@ proc CheckPrjConfig { fileset } {
    }   
    
    # Check the Vivado version (check_syntax added to Vivado in 2016.1)
-   if { $::env(VIVADO_VERSION) >= 2016.1 } {   
+   if { [VersionCompare 2016.1] >= 0 } {
       # Check for syntax errors
       set syntaxReport [check_syntax -fileset ${fileset} -return_string -quiet -verbose]
       set syntaxReport [split ${syntaxReport} "\n"]
@@ -949,6 +950,48 @@ proc SubmoduleCheck { name lockTag  {mustBeExact ""} } {
    }
 }
 
+## Compares currnet vivado version to a argument value
+proc VersionCompare { versionLock } {
+
+   # Check if missing patch version number field
+   if { [expr {[llength [split $::env(VIVADO_VERSION) .]] - 1}] == 1 } {
+      set tag "$::env(VIVADO_VERSION).0"
+   } else {
+      set tag $::env(VIVADO_VERSION)
+   }
+   
+   # Check if missing patch version number field
+   if { [expr {[llength [split ${versionLock} .]] - 1}] == 1 } {
+      set lockTag "${versionLock}.0"
+   } else {
+      set lockTag ${versionLock}
+   }   
+   
+   # Parse the strings
+   scan $tag     "%d.%d.%d" major minor patch  
+   scan $lockTag "%d.%d.%d" majorLock minorLock patchLock   
+   
+   # Compare the tags
+   set validTag [CompareTags ${tag} ${lockTag}]   
+   
+   # # Debug Messages
+   # puts "VIVADO_VERSION: ${tag}"
+   # puts "compareVersion: ${lockTag}"
+   # puts "validTag:       ${validTag}"   
+   
+   # Check the validTag flag
+   if { ${validTag} != 1 } {
+      # compareVersion > VIVADO_VERSION
+      return -1
+   } elseif { ${major} == ${majorLock} && ${minor} == ${minorLock} && ${patch} == ${patchLock} } {
+      # compareVersion = VIVADO_VERSION
+      return 0
+   } else {
+      # compareVersion < VIVADO_VERSION
+      return 1
+   }   
+}
+
 ###############################################################
 #### Partial Reconfiguration Functions ########################
 ###############################################################
@@ -1087,7 +1130,7 @@ proc CreateDebugCore {ilaName} {
    delete_debug_core -quiet [get_debug_cores ${ilaName}]
 
    # Create the debug core
-   if { $::env(VIVADO_VERSION) <= 2017.2 } {   
+   if { [VersionCompare 2017.2] <= 0 } {
       create_debug_core ${ilaName} labtools_ila_v3
    } else {
       create_debug_core ${ilaName} ila
@@ -1139,7 +1182,7 @@ proc WriteDebugProbes {ilaName {filePath ""}} {
    delete_debug_port [get_debug_ports [GetCurrentProbe ${ilaName}]]
 
    # Check if write_debug_probes is support
-   if { $::env(VIVADO_VERSION) <= 2017.2 } {
+   if { [VersionCompare 2017.2] <= 0 } {
       # Write the port map file
       write_debug_probes -force ${filePath}
    } else {

--- a/vivado_project.tcl
+++ b/vivado_project.tcl
@@ -50,7 +50,7 @@ set_property nl.process_corner slow   [get_filesets sim_1]
 set_property nl.sdf_anno true         [get_filesets sim_1]
 set_property SOURCE_SET sources_1     [get_filesets sim_1]
 
-if { [expr { ${VIVADO_VERSION} <= 2014.2 }] } {
+if { [VersionCompare 2014.2] <= 0 } {
    set_property runtime {}             [get_filesets sim_1]
    set_property xelab.debug_level all  [get_filesets sim_1]
    set_property xelab.mt_level auto    [get_filesets sim_1]

--- a/vivado_properties.tcl
+++ b/vivado_properties.tcl
@@ -30,7 +30,7 @@ set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado_mess
 set_property STEPS.WRITE_BITSTREAM.TCL.PRE             ${RUCKUS_DIR}/vivado_messages.tcl [get_runs impl_1]
 
 # Refer to http://www.xilinx.com/support/answers/65415.html
-if { [expr { ${VIVADO_VERSION} >= 2016.1 }] } {
+if { [VersionCompare 2016.1] >= 0 } {
    set_property STEPS.SYNTH_DESIGN.ARGS.ASSERT true [get_runs synth_1]
 }
 
@@ -43,10 +43,10 @@ if { $::env(GEN_BIN_IMAGE) != 0 } {
 }
 
 # Automatically use the checkpoint from the previous run
-if { [expr { ${VIVADO_VERSION} >= 2019.1 }] } {
+if { [VersionCompare 2019.1] >= 0 } {
    set_property AUTO_INCREMENTAL_CHECKPOINT 1 [get_runs synth_1]
 }
-if { [expr { ${VIVADO_VERSION} >= 2018.3 }] } {
+if { [VersionCompare 2018.3] >= 0 } {
    set_property AUTO_INCREMENTAL_CHECKPOINT 1 [get_runs impl_1]
 }
 

--- a/vivado_sdk_elf.tcl
+++ b/vivado_sdk_elf.tcl
@@ -19,7 +19,7 @@
 source $::env(RUCKUS_DIR)/vivado_env_var.tcl
 
 # Check the Vivado version (Refer to AR#66629)
-if { [expr { ${VIVADO_VERSION} < 2016.1 }] } {
+if { [VersionCompare 2016.1] < 0 } {
    # Generate .ELF for Vivado 2015.4 (or earlier) ....  Refer to AR#66629
    sdk set_workspace ${SDK_PRJ}
    sdk build_project  -type all

--- a/vivado_sdk_prj.tcl
+++ b/vivado_sdk_prj.tcl
@@ -19,7 +19,7 @@ set EmptyApp "Empty Application"
 exec rm -rf ${SDK_PRJ}
 
 # Check the Vivado version (Refer to AR#66629)
-if { [expr { ${VIVADO_VERSION} < 2016.1 }] } {
+if { [VersionCompare 2016.1] < 0 } {
    # Setup the project for Vivado 2015.4 (or earlier) ....  Refer to AR#66629
    file mkdir ${SDK_PRJ}
    file copy -force ${OUT_DIR}/${VIVADO_PROJECT}.runs/impl_1/${PROJECT}.sysdef ${SDK_PRJ}/${PROJECT}.hdf

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -110,7 +110,7 @@ set simTbOutDir ${OUT_DIR}/${PROJECT}_project.sim/sim_1/behav
 set simTbFileName [get_property top [get_filesets sim_1]]
 
 # Set the compile/elaborate options
-set vloganOpt "-nc -l +v2k -xlrm -kdb"
+set vloganOpt "-nc -l +v2k -xlrm -kdb +define+SIM_SPEED_UP"
 set vhdlanOpt "-nc -l +v2k -xlrm -kdb"
 set elabOpt "+warn=none -kdb -lca -debug_access+all"
 

--- a/vivado_vcs.tcl
+++ b/vivado_vcs.tcl
@@ -8,9 +8,9 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 # VCS + Verdi GUI + Ubuntu 19.04 Notes:
-# $ wget http://ftp.us.debian.org/debian/pool/main/libp/libpng/libpng12-0_1.2.50-2+deb8u3_amd64.deb
-# $ dpkg -x libpng12-0_1.2.50-2+deb8u3_amd64.deb .
-# $ cp lib/x86_64-linux-gnu/libpng12.so.0 /afs/slac.stanford.edu/g/reseng/vol27/verdi/Verdi_P-2019.06/platform/LINUXAMD64/bin/.
+# Download https://www.dropbox.com/s/79x3imq73tcqyw4/libpng12-0_1.2.54-1ubuntu1b_amd64.deb?dl=1
+# $ sudo dpkg -i libpng12-0_1.2.54-1ubuntu1b_amd64.deb
+# $ sudo apt install -f
 ##############################################################################
 
 ## \file vivado_vcs.tcl
@@ -112,7 +112,8 @@ set simTbFileName [get_property top [get_filesets sim_1]]
 # Set the compile/elaborate options
 set vloganOpt "-nc -l +v2k -xlrm -kdb +define+SIM_SPEED_UP"
 set vhdlanOpt "-nc -l +v2k -xlrm -kdb"
-set elabOpt "+warn=none -kdb -lca -debug_access+all"
+# set elabOpt "+warn=none -kdb -lca -debug_access+all"
+set elabOpt "+warn=none -kdb -lca"
 
 #####################################################################################################
 ## Compile the VCS Simulation Library


### PR DESCRIPTION
### Description 
- adding vivado patch version checking support #106
- Avoid placing an extra '0' on the end of the githash in the filename #107
- adding support for user gui startup script
- Added vlogan option: +define+SIM_SPEED_UP
  - This is commonly used in Xilinx IP cores to speed up the simulation. 
Example: Refer to Integrated 100G Ethernet v2.6 (PG203) on page 216