### PR TITLE
Maximizing max thread by default

### DIFF
--- a/vivado_project.tcl
+++ b/vivado_project.tcl
@@ -70,10 +70,11 @@ if { [VersionCompare 2014.2] <= 0 } {
 
 # Enable general project multi-threading
 set cpuNum [GetCpuNumber]
+set_param general.maxThreads ${cpuNum}
 if { ${cpuNum} >= 8 } { 
-   set_param general.maxThreads 8
+   set_param synth.maxThreads 8
 } else {
-   set_param general.maxThreads ${cpuNum}
+   set_param synth.maxThreads ${cpuNum}
 }
 
 # # https://www.xilinx.com/support/answers/62908.html


### PR DESCRIPTION
### Description
- Inspired by https://gitlab.cern.ch/asvetek/apxfs-ref-prj/blob/8430cce0/apd1/vivado/properties.tcl
- general.maxThreads doesn't appear to have upper limit
- synth.maxThreads can't be greater than 8
```
set_param synth.maxThreads ${cpuNum}
ERROR: [Common 17-154] Value should be >= 1 and <= 8
```