### PR TITLE
Put BuildInfoPkg.vhd in ruckus library

### DIFF
--- a/vivado_sources.tcl
+++ b/vivado_sources.tcl
@@ -70,13 +70,14 @@ set pathToPkg "${OUT_DIR}/${VIVADO_PROJECT}.srcs/BuildInfoPkg.vhd"
 exec mkdir -p ${OUT_DIR}/${VIVADO_PROJECT}.srcs
 set out [open ${pathToPkg} w]
 puts ${out} "library ieee;" 
-puts ${out} "use ieee.std_logic_1164.all;" 
-puts ${out} "use work.StdRtlPkg.all;" 
+puts ${out} "use ieee.std_logic_1164.all;"
+puts ${out} "library surf;"
+puts ${out} "use surf.StdRtlPkg.all;" 
 puts ${out} "package BuildInfoPkg is" 
 puts ${out} "constant BUILD_INFO_C : BuildInfoType :=x\"${gitHash}${fwVersion}${buildString}\";"
 puts ${out} "end BuildInfoPkg;" 
 close ${out}
-loadSource -path ${pathToPkg} 
+loadSource -lib ruckus -path ${pathToPkg} 
 
 ########################################################
 ## Check for change in hash or fwVersion between builds


### PR DESCRIPTION
This puts `BuildInfoPkg.vhd` into a library called `ruckus`. 

This is related to our push to vhdl libraries.
https://github.com/slaclab/surf/pull/541