### PR TITLE
TCL support for loadBlockDesign & CopyBdCores

### DIFF
--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -180,10 +180,10 @@ proc BuildIpCores { } {
 }
 
 ## Copies all IP cores from the build tree to source tree
-proc CopyIpCores { } {
+proc CopyIpCores { {copyDcp true} {copySourceCode false} } {
    # Get variables
    source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
-   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl   
+   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl
    
    # Make sure the IP Cores have been built
    BuildIpCores
@@ -197,53 +197,34 @@ proc CopyIpCores { } {
       foreach corePntr [get_ips] {
          # Create a copy of the IP Core in the source tree
          foreach coreFilePntr ${ipList} {
-            if { [ string match *${corePntr}* ${coreFilePntr} ] } { 
+            if { [ string match *${corePntr}* ${coreFilePntr} ] } {
                # Overwrite the existing .xci file in the source tree
                set SRC [get_files ${corePntr}.xci]
                set DST ${coreFilePntr}
                exec cp ${SRC} ${DST}
-               puts "exec cp ${SRC} ${DST}"    
-               # Overwrite the existing .dcp file in the source tree               
-               set SRC [string map {.xci .dcp} ${SRC}]
-               set DST [string map {.xci .dcp} ${DST}]
-               exec cp ${SRC} ${DST}    
-               puts "exec cp ${SRC} ${DST}"    
+               puts "exec cp ${SRC} ${DST}"
+               # Check if copying .DCP output
+               if {copyDcp} {
+                  # Overwrite the existing .dcp file in the source tree
+                  set SRC [string map {.xci .dcp} ${SRC}]
+                  set DST [string map {.xci .dcp} ${DST}]
+                  exec cp ${SRC} ${DST}
+                  puts "exec cp ${SRC} ${DST}"
+               }
+               # Check if copying IP Core's the source tree
+               if {copySourceCode} {
+                  set SRC [get_files ${corePntr}.xci]
+                  set DST ${coreFilePntr}
+                  set SRC  [string trim ${SRC} ${corePntr}.xci]
+                  set DST  [string trim ${DST} ${corePntr}.xci]
+                  exec cp -rf ${SRC} ${DST}
+                  puts "exec cp -rf ${SRC} ${DST}"
+               }
             }
-         }        
+         }
       }
    }
 }  
-
-## Copies all IP cores from the build tree to source tree (with source code)
-proc CopyIpCoresDebug { } {
-   # Get variables
-   source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
-   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl   
-   
-   # Make sure the IP Cores have been built
-   BuildIpCores
-   
-   # Get the IP list
-   set ipList [read [open ${OUT_DIR}/ipList.txt]]
-   
-   # Check if the target project has IP cores
-   if { ${ipList} != "" } {
-      # Loop through the IP cores
-      foreach corePntr [get_ips] {
-         # Create a copy of the IP Core in the source tree
-         foreach coreFilePntr ${ipList} {
-            if { [ string match *${corePntr}* ${coreFilePntr} ] } { 
-               set SRC [get_files ${corePntr}.xci]
-               set DST ${coreFilePntr}            
-               set SRC  [string trim ${SRC} ${corePntr}.xci]
-               set DST  [string trim ${DST} ${corePntr}.xci]
-               exec cp -rf ${SRC} ${DST}    
-               puts "exec cp -rf ${SRC} ${DST}"    
-            }
-         }        
-      }
-   }
-}   
 
 ## Copies all block designs from the build tree to source tree
 proc CopyBdCores { } {

--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -204,15 +204,15 @@ proc CopyIpCores { {copyDcp true} {copySourceCode false} } {
                exec cp ${SRC} ${DST}
                puts "exec cp ${SRC} ${DST}"
                # Check if copying .DCP output
-               if {copyDcp} {
+               if { ${copyDcp} } {
                   # Overwrite the existing .dcp file in the source tree
                   set SRC [string map {.xci .dcp} ${SRC}]
                   set DST [string map {.xci .dcp} ${DST}]
                   exec cp ${SRC} ${DST}
                   puts "exec cp ${SRC} ${DST}"
                }
-               # Check if copying IP Core's the source tree
-               if {copySourceCode} {
+               # Check if copying IP Core's the source code
+               if { ${copySourceCode} } {
                   set SRC [get_files ${corePntr}.xci]
                   set DST ${coreFilePntr}
                   set SRC  [string trim ${SRC} ${corePntr}.xci]
@@ -227,7 +227,7 @@ proc CopyIpCores { {copyDcp true} {copySourceCode false} } {
 }  
 
 ## Copies all block designs from the build tree to source tree
-proc CopyBdCores { {copySourceCode false} } {
+proc CopyBdCores { {createTcl true} {copySourceCode false} } {
    # Get variables
    source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
    source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl
@@ -248,8 +248,13 @@ proc CopyBdCores { {copySourceCode false} } {
                set DST ${bdFilePntr}
                exec cp ${SRC} ${DST}
                puts "exec cp ${SRC} ${DST}"
-               # Check if copying block design's the source tree
-               if {copySourceCode} {
+               # Check if creating a .TCL file for the source tree
+               if { ${createTcl} } {
+                  set fbasename [file rootname ${bdFilePntr}]
+                  write_bd_tcl -force ${fbasename}.tcl
+               }
+               # Check if copying block design's the source code
+               if { ${copySourceCode} } {
                   set SRC ${bdPntr}
                   set DST ${bdFilePntr}
                   set SRC  [string trim ${SRC} ${strip}.bd]

--- a/vivado_proc.tcl
+++ b/vivado_proc.tcl
@@ -227,13 +227,13 @@ proc CopyIpCores { {copyDcp true} {copySourceCode false} } {
 }  
 
 ## Copies all block designs from the build tree to source tree
-proc CopyBdCores { } {
+proc CopyBdCores { {copySourceCode false} } {
    # Get variables
    source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
-   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl   
+   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl
    
    # Get the BD list
-   set bdList [read [open ${OUT_DIR}/bdList.txt]]   
+   set bdList [read [open ${OUT_DIR}/bdList.txt]]
    
    # Check if the target project has block designs
    if { ${bdList} != "" } {
@@ -242,43 +242,23 @@ proc CopyBdCores { } {
          # Create a copy of the IP Core in the source tree
          foreach bdFilePntr ${bdList} {
             set strip [file rootname [file tail ${bdPntr}]]
-            if { [ string match *${strip}.bd ${bdFilePntr} ] } { 
+            if { [ string match *${strip}.bd ${bdFilePntr} ] } {
                # Overwrite the existing .bd file in the source tree
                set SRC ${bdPntr}
                set DST ${bdFilePntr}
                exec cp ${SRC} ${DST}
-               puts "exec cp ${SRC} ${DST}"    
+               puts "exec cp ${SRC} ${DST}"
+               # Check if copying block design's the source tree
+               if {copySourceCode} {
+                  set SRC ${bdPntr}
+                  set DST ${bdFilePntr}
+                  set SRC  [string trim ${SRC} ${strip}.bd]
+                  set DST  [string trim ${DST} ${strip}.bd]
+                  exec cp -rf ${SRC} ${DST}
+                  puts "exec cp -rf ${SRC} ${DST}"
+               }
             }
-         }        
-      }
-   }
-} 
-
-## Copies all block designs from the build tree to source tree (with source code)
-proc CopyBdCoresDebug { } {
-   # Get variables
-   source -quiet $::env(RUCKUS_DIR)/vivado_env_var.tcl
-   source -quiet $::env(RUCKUS_DIR)/vivado_messages.tcl   
-   
-   # Get the BD list
-   set bdList [read [open ${OUT_DIR}/bdList.txt]]   
-   
-   # Check if the target project has block designs
-   if { ${bdList} != "" } {
-      # Loop through the has block designs
-      foreach bdPntr [get_files {*.bd}] {
-         # Create a copy of the IP Core in the source tree
-         foreach bdFilePntr ${bdList} {
-            set strip [file rootname [file tail ${bdPntr}]]
-            if { [ string match *${strip}.bd ${bdFilePntr} ] } { 
-               set SRC ${bdPntr}
-               set DST ${bdFilePntr}         
-               set SRC  [string trim ${SRC} ${strip}.bd]
-               set DST  [string trim ${DST} ${strip}.bd]
-               exec cp -rf ${SRC} ${DST}    
-               puts "exec cp -rf ${SRC} ${DST}"    
-            }
-         }        
+         }
       }
    }
 } 


### PR DESCRIPTION
### Description
- adding .TCL file support to loadBlockDesign()
  - Example: `loadBlockDesign -path "$::DIR_PATH/bd/2018.3/MicroblazeBasicCore.tcl"`
- adding createTcl support to CopyBdCores
- combining CopyBdCores and CopyBdCoresDebug together
- combining CopyIpCores and CopyIpCoresDebug together

### Why TCL support for loadBlockDesign()
- .bd is a bit annoying - it contains the graphical placement info, etc. that's not so useful.  
- Hard to edit in a text editor
- TCL is easy to modify. (Example: change data bus 32->128bits) without opening Vivado GUI

### JIRA
[ESCORE-500](https://jira.slac.stanford.edu/browse/ESCORE-500)