### PR TITLE
Pyrogue Update

### DIFF
--- a/vivado/post_route.tcl
+++ b/vivado/post_route.tcl
@@ -30,7 +30,7 @@ if { [CheckTiming false] == true } {
    #########################################################
    ## Check if need to include python files with build
    #########################################################   
-   if { [file isdirectory ${PROJ_DIR}/python] == 1 } {
+   if { [expr [info exists ::env(GEN_PYROGUE_ZIP)]] == 1 } {
       source ${RUCKUS_DIR}/vivado/pyrogue.tcl
    }   
    


### PR DESCRIPTION
### Description
- For auto-build generation, instead of checking if `${PROJ_DIR}/python` exists use if `::env(GEN_PYROGUE_ZIP)` exist
- Requires defining GEN_PYROGUE_ZIP in Makefile