### PR TITLE
MicroblazeBasicCore Development Updates

### DIFF
--- a/MicroblazeBasicCore/sdk/prj.tcl
+++ b/MicroblazeBasicCore/sdk/prj.tcl
@@ -25,8 +25,8 @@ if { [expr { ${VIVADO_VERSION} < 2016.1 }] } {
    file copy -force ${OUT_DIR}/${VIVADO_PROJECT}.runs/impl_1/${PROJECT}.sysdef ${SDK_PRJ}/${PROJECT}.hdf
    sdk set_workspace ${SDK_PRJ}
    sdk create_hw_project  -name hw_0  -hwspec ${SDK_PRJ}/${PROJECT}.hdf
-   sdk create_bsp_project -name bsp_0 -proc microblaze_0 -hwproject hw_0 -os standalone
-   sdk create_app_project -name app_0 -app ${EmptyApp} -proc microblaze_0 -hwproject hw_0 -bsp bsp_0 -os standalone -lang c++
+   sdk create_bsp_project -name bsp_0 -proc $::env(EMBED_PROC) -hwproject hw_0 -os standalone
+   sdk create_app_project -name app_0 -app ${EmptyApp} -proc $::env(EMBED_PROC) -hwproject hw_0 -bsp bsp_0 -os standalone -lang c++
    file delete -force ${SDK_PRJ}/app_0/src/main.cc
    # Configure the release build
    sdk get_build_config -app app_0 build-config release
@@ -43,8 +43,8 @@ if { [expr { ${VIVADO_VERSION} < 2016.1 }] } {
    exec cp -f ${OUT_DIR}/${VIVADO_PROJECT}.runs/impl_1/${PROJECT}.sysdef ${SDK_PRJ}/${PROJECT}.hdf
    sdk setws ${SDK_PRJ}
    sdk createhw  -name hw_0  -hwspec ${SDK_PRJ}/${PROJECT}.hdf
-   sdk createbsp -name bsp_0 -proc microblaze_0 -hwproject hw_0 -os standalone
-   sdk createapp -name app_0 -app ${EmptyApp} -proc microblaze_0 -hwproject hw_0 -bsp bsp_0 -os standalone -lang c++
+   sdk createbsp -name bsp_0 -proc $::env(EMBED_PROC) -hwproject hw_0 -os standalone
+   sdk createapp -name app_0 -app ${EmptyApp} -proc $::env(EMBED_PROC) -hwproject hw_0 -bsp bsp_0 -os standalone -lang c++
    exec rm -f ${SDK_PRJ}/app_0/src/main.cc
    # Configure the debug build
    sdk configapp -app app_0 build-config debug

--- a/MicroblazeBasicCore/vitis/prj.tcl
+++ b/MicroblazeBasicCore/vitis/prj.tcl
@@ -27,7 +27,7 @@ setws ${VITIS_PRJ}
 app create \
    -name app_0 \
    -hw ${OUT_DIR}/${PROJECT}.xsa  \
-   -proc microblaze_0 \
+   -proc $::env(EMBED_PROC) \
    -template {Empty Application} \
    -os standalone \
    -lang {c++}

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -185,6 +185,10 @@ ifndef LD_PRELOAD
 export LD_PRELOAD = 
 endif
 
+ifndef EMBED_PROC
+export EMBED_PROC = microblaze_0
+endif
+
 ifneq (, $(shell which vitis 2>/dev/null))
    export EMBED_TYPE = Vitis
    export EMBED_GUI  = vitis -workspace $(OUT_DIR)/$(VIVADO_PROJECT).vitis -vmargs -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false
@@ -254,6 +258,7 @@ test:
 	@echo GIT_HASH_LONG: $(GIT_HASH_LONG)
 	@echo GIT_HASH_SHORT: $(GIT_HASH_SHORT)
 	@echo IMAGENAME: $(IMAGENAME)
+	@echo EMBED_PROC: $(EMBED_PROC)
 	@echo EMBED_TYPE: $(EMBED_TYPE)
 	@echo EMBED_GUI: $(EMBED_GUI)
 	@echo EMBED_ELF: $(EMBED_ELF)

--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -105,7 +105,6 @@ set_msg_config -id {Power 33-332}       -new_severity INFO;# Route: Found switch
 set_msg_config -id {Synth 8-614}      -new_severity ERROR;# SYNTH: Signal not in the sensitivity list
 set_msg_config -id {Synth 8-3512}     -new_severity ERROR;# SYNTH: Assigned value in logic is out of range 
 set_msg_config -id {Synth 8-327}      -new_severity ERROR;# SYNTH: Inferred latch
-set_msg_config -id {Synth 8-5835}     -new_severity ERROR;# SYNTH: Resources of type BRAM have been overutilized
 set_msg_config -id {VRFC 10-664}      -new_severity ERROR;# SIM:   expression has XXX elements ; expected XXX
 set_msg_config -id {filemgmt 20-1318} -new_severity ERROR;# FILEMGMT: Duplicate entities/files found in the same library
 
@@ -123,6 +122,7 @@ set_msg_config -id {Synth 8-3330}      -new_severity "CRITICAL WARNING";# SYNTH:
 set_msg_config -id {Synth 8-3919}      -new_severity "CRITICAL WARNING";# SYNTH: Null Assignment in logic
 set_msg_config -id {Synth 8-153}       -new_severity "CRITICAL WARNING";# SYNTH: Case statement has an input that will never be executed
 set_msg_config -id {Synth 8-3295}      -new_severity "CRITICAL WARNING";# SYNTH: Tying undriven pin to a constant
+set_msg_config -id {Synth 8-5835}      -new_severity "CRITICAL WARNING";# SYNTH: Resources of type BRAM have been overutilized. Will try to implement using LUT-RAM.
 
 ########################################################
 ## Modifying CRITICAL_WARNING messaging

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -460,6 +460,18 @@ proc CheckVivadoVersion { } {
       puts "********************************************************\n\n\n\n\n"
       return -code error
    }
+   # Check for unsupported versions of ruckus + Vitis
+   if { [VersionCompare 2019.1] > 0 ||
+        [VersionCompare 2020.1] < 0 ||
+        [expr [info exists ::env(VITIS_SRC_PATH)]] == 1 } {
+      # Here's why Vitis 2019.2 not supported in ruckus
+      # https://forums.xilinx.com/t5/Embedded-Development-Tools/SDK-banned-from-Vivado-2019-2/td-p/1042059
+      puts "\n\n\n\n\n********************************************************"
+      puts "ruckus does NOT support Vitis $::env(VIVADO_VERSION)"
+      puts "https://confluence.slac.stanford.edu/x/n4-jCg"
+      puts "********************************************************\n\n\n\n\n"
+      return -code error
+   }
    # Check if version is newer than what official been tested
    if { [VersionCompare 2019.2.0] > 0 } {
       puts "\n\n\n\n\n********************************************************"

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -461,8 +461,8 @@ proc CheckVivadoVersion { } {
       return -code error
    }
    # Check for unsupported versions of ruckus + Vitis
-   if { [VersionCompare 2019.1] > 0 ||
-        [VersionCompare 2020.1] < 0 ||
+   if { [VersionCompare 2019.1] > 0 &&
+        [VersionCompare 2020.1] < 0 &&
         [expr [info exists ::env(VITIS_SRC_PATH)]] == 1 } {
       # Here's why Vitis 2019.2 not supported in ruckus
       # https://forums.xilinx.com/t5/Embedded-Development-Tools/SDK-banned-from-Vivado-2019-2/td-p/1042059


### PR DESCRIPTION
### Description
- EMBED_PROC helps with the situation when both MicroblazeBasicCore.vhd and a Ultrascale MIG core is used and vivado rename the MicroblazeBasicCore.vhd's `proc` from `microblaze_0` to `U_CORE_U_CPU_U_Microblaze_microblaze_0`
  - Elimate the requirement for a custom user script build and simply defined EMBED_PROC in Makefile instead