### PR TITLE
Release Gen Updates

### DIFF
--- a/releaseGen.py
+++ b/releaseGen.py
@@ -294,7 +294,7 @@ def buildRogueFile(zipName, cfg, ver, relName, relData, imgList):
     topInit = 'python/' + cfg['TopRoguePackage'] + '/__init__.py'
     topPath = None
 
-    with zipfile.ZipFile(zipName,'w') as zf:
+    with zipfile.ZipFile(file=zipName, mode='w', compression=zipfile.ZIP_BZIP2, compresslevel=9) as zf:
         print(f"\nCreating Rogue zipfile {zipName}")
 
         # Add license file, should be at top level

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -363,7 +363,7 @@ elf :
 #### Release ##################################################
 ###############################################################
 .PHONY : release
-release : 
+release : $(VIVADO_DEPEND)
 	$(call ACTION_HEADER,"Generaring Release")
 	@cd $(OUT_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE) --push
 
@@ -371,7 +371,7 @@ release :
 #### Release Files ############################################
 ###############################################################
 .PHONY : release_files
-release_files : 
+release_files : $(VIVADO_DEPEND)
 	$(call ACTION_HEADER,"Generaring Release Files")
 	@cd $(OUT_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE)
 


### PR DESCRIPTION
### Description
- [adding BZIP2 compression to the release ZIP file](https://docs.python.org/3/library/bz2.html#bz2.BZ2File)
- releaseGen.py depends on the ~/firmware/build/VivadoProject dir

### Compression Example
- v1.0.0 is with original code (no compression)
- v2.0.0 is with BZIP2 compression
```bash
$ ls -lath /u1/ruckman/build/SmurfKcu1500RssiOffload10GbE/rogue*
-rw-r--r-- 1 ruckman re 103M Feb 11 09:33 /u1/ruckman/build/SmurfKcu1500RssiOffload10GbE/rogue_SmurfKcu1500RssiOffload10GbE_v1.0.0.zip
-rw-r--r-- 1 ruckman re  31M Feb 11 09:33 /u1/ruckman/build/SmurfKcu1500RssiOffload10GbE/rogue_SmurfKcu1500RssiOffload10GbE_v2.0.0.zip
```