### PR TITLE
Release Script Updates

### DIFF
--- a/releaseGen.py
+++ b/releaseGen.py
@@ -205,9 +205,9 @@ def selectBuildImages(cfg, relName, relData):
             if target in fn:
                 fileName = fn[len(target):]
                 if '_' in fileName:
-                    baseList.add(fn.split('_')[0])
+                    baseList.add(target+fileName.split('_')[0])
                 else:
-                    baseList.add(fn.split('.')[0])
+                    baseList.add(target+fileName.split('.')[0])
 
         sortList = sorted(baseList)
         for idx,val in enumerate(sortList):

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -485,8 +485,12 @@ def pushRelease(cfg, relName, ver, tagAttach, prev):
     if locRepo.is_dirty():
         raise(Exception("Cannot create tag! Git repo is dirty!"))
 
-    tag = f'{relName}_{ver}'
-    msg = f'{relName} version {ver}'
+    if relName != 'all':
+        tag = f'{relName}_{ver}'
+        msg = f'{relName} version {ver} Release'
+    else:
+        tag = f'{ver}'
+        msg = f'version {ver} Release'
 
     print("\nLogging into github....\n")
 

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -203,7 +203,8 @@ def selectBuildImages(cfg, relName, relData):
 
         for fn in dirList:
             if target in fn:
-                if '_' in fn:
+                fileName = fn[len(target):]
+                if '_' in fileName:
                     baseList.add(fn.split('_')[0])
                 else:
                     baseList.add(fn.split('.')[0])

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -480,15 +480,20 @@ def pushRelease(cfg, relName, ver, tagAttach, prev):
     url = locRepo.remote().url
     if not url.endswith('.git'): url += '.git'
 
+    # Get the git repo's name (assumption that exists in the github.com/slaclab organization)
     project = re.compile(r'slaclab/(?P<name>.*?)(?P<ext>\.git?)').search(url).group('name')
 
+    # Prevent "dirty" git clone (uncommitted code) from pushing tags
     if locRepo.is_dirty():
         raise(Exception("Cannot create tag! Git repo is dirty!"))
 
-    if relName != 'all':
+    # Check the release name does NOT match git repo name
+    if relName != project:
+        # Target Level Release
         tag = f'{relName}_{ver}'
         msg = f'{relName} version {ver} Release'
     else:
+        # Repo Level Release
         tag = f'{ver}'
         msg = f'version {ver} Release'
 

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -528,8 +528,10 @@ if __name__ == "__main__":
     ver, prev = getVersion()
 
     print("Release = {}".format(relName))
-    print("Images = {}".format(imgList))
     print("Version = {}".format(ver))
+    print("Images  = ")
+    for imgName in imgList:
+        print("\t{}".format(imgName))
 
     tagAttach = imgList
 

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -20,6 +20,10 @@ ifndef TOP_DIR
 export TOP_DIR  = $(abspath $(PROJ_DIR)/../..)
 endif
 
+ifndef RELEASE_DIR
+export RELEASE_DIR  = $(abspath $(TOP_DIR)/release)
+endif
+
 ifndef MODULES
 export MODULES = $(TOP_DIR)/submodules
 endif
@@ -270,12 +274,6 @@ test:
 ###############################################################
 .PHONY : dir
 dir:
-
-###############################################################
-#### Vivado Project ###########################################
-###############################################################
-$(VIVADO_DEPEND) :
-	$(call ACTION_HEADER,"Vivado Project Creation")
 	@test -d $(TOP_DIR)/build/ || { \
 			 echo ""; \
 			 echo "Build directory missing!"; \
@@ -287,9 +285,16 @@ $(VIVADO_DEPEND) :
 			 echo "Or by creating a symbolic link to a directory on another disk:"; \
 			 echo "   ln -s $(TMP_DIR) $(TOP_DIR)/build"; \
 			 echo ""; false; }
-	@test -d $(OUT_DIR) || mkdir $(OUT_DIR)
+	@test -d $(OUT_DIR)     || mkdir $(OUT_DIR)
+	@test -d $(RELEASE_DIR) || mkdir $(RELEASE_DIR)
 	@cd $(OUT_DIR); rm -f firmware
 	@cd $(OUT_DIR); ln -s $(TOP_DIR) firmware
+
+###############################################################
+#### Vivado Project ###########################################
+###############################################################
+$(VIVADO_DEPEND) : dir
+	$(call ACTION_HEADER,"Vivado Project Creation")
 	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/project.tcl -notrace 
 
 ###############################################################
@@ -363,17 +368,17 @@ elf :
 #### Release ##################################################
 ###############################################################
 .PHONY : release
-release : $(VIVADO_DEPEND)
+release : dir
 	$(call ACTION_HEADER,"Generaring Release")
-	@cd $(OUT_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE) --push
+	@cd $(RELEASE_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE) --push
 
 ###############################################################
 #### Release Files ############################################
 ###############################################################
 .PHONY : release_files
-release_files : $(VIVADO_DEPEND)
+release_files : dir
 	$(call ACTION_HEADER,"Generaring Release Files")
-	@cd $(OUT_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE)
+	@cd $(RELEASE_DIR); python3 $(RUCKUS_DIR)/releaseGen.py --project=$(TOP_DIR) --release=$(RELEASE)
 
 ###############################################################
 #### Vivado PyRogue ###########################################

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -21,7 +21,7 @@ export TOP_DIR  = $(abspath $(PROJ_DIR)/../..)
 endif
 
 ifndef RELEASE_DIR
-export RELEASE_DIR  = $(abspath $(TOP_DIR)/release)
+export RELEASE_DIR = $(TOP_DIR)/release
 endif
 
 ifndef MODULES


### PR DESCRIPTION
### Description
- adding RELEASE_DIR variable
- make PROJECT variable agnostic to string structure
  - Example: Supports `export PROJECT=ClinkFebPgp3_1ch` target name
- adding support for repo level release