### PR TITLE
releaseGen.py Updates

### DIFF
--- a/releaseGen.py
+++ b/releaseGen.py
@@ -398,7 +398,7 @@ def buildRogueFile(zipName, cfg, ver, relName, relData, imgList):
         lFile = os.path.join(args.project,cfg['GitBase'],'LICENSE.txt')
         zf.write(lFile,'LICENSE.txt')
 
-        # Walk through collected list
+        # Walk through collected python list
         for e in pList:
             dst = 'python/' + e['subPath']
 
@@ -413,14 +413,24 @@ def buildRogueFile(zipName, cfg, ver, relName, relData, imgList):
             if e['type'] == 'folder':
                 packList.append(e['subPath'])
 
+        # Walk through collected configuration list
         for e in cList:
             dst = 'python/' + cfg['TopRoguePackage'] + '/config/' + e['subPath']
             zf.write(e['fullPath'],dst)
 
+        # Walk through collected image list
         for e in imgList:
-            dst = 'python/' + cfg['TopRoguePackage'] + '/images/' + os.path.basename(e)
-            zf.write(e,dst)
+            # Check if a .gz version exists
+            if os.path.isfile(e+'.gz'):
+                # Write the compressed version into the rogue_XXX.zip instead
+                img = e+'.gz'
+            else:
+                # Using non-compressed version of the file
+                img = e
+            dst = 'python/' + cfg['TopRoguePackage'] + '/images/' + os.path.basename(img)
+            zf.write(img,dst)
 
+        # Walk through collected script list
         for e in sList:
             dst = 'scripts/' + os.path.basename(e)
             zf.write(e,dst)

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -238,8 +238,8 @@ def selectBuildImages(cfg, relName, relData):
             else:
                 buildName = sortList[idx]
 
-        tarExp = [re.compile(f'{buildName}\.{ext}') for ext in extensions]
-        tarExp.extend([re.compile(f'{buildName}_.\w*\.{ext}') for ext in extensions])
+        tarExp = [re.compile(f'{buildName}\.{ext}$') for ext in extensions]
+        tarExp.extend([re.compile(f'{buildName}_.\w*\.{ext}$') for ext in extensions])
 
         print(f"\nFinding images for target {target}, build {buildName}...")
         for f in dirList:
@@ -421,9 +421,9 @@ def buildRogueFile(zipName, cfg, ver, relName, relData, imgList):
         # Walk through collected image list
         for e in imgList:
             # Check if a .gz version exists
-            if os.path.isfile(e+'.gz'):
+            if os.path.isfile(e + '.gz'):
                 # Write the compressed version into the rogue_XXX.zip instead
-                img = e+'.gz'
+                img = e + '.gz'
             else:
                 # Using non-compressed version of the file
                 img = e

--- a/releaseGen.py
+++ b/releaseGen.py
@@ -428,7 +428,10 @@ def buildRogueFile(zipName, cfg, ver, relName, relData, imgList):
                 # Using non-compressed version of the file
                 img = e
             dst = 'python/' + cfg['TopRoguePackage'] + '/images/' + os.path.basename(img)
-            zf.write(img,dst)
+
+            # Check that the file does NOT already exists
+            if dst not in zf.namelist():
+                zf.write(img,dst)
 
         # Walk through collected script list
         for e in sList:

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -45,7 +45,7 @@ export GIT_BYPASS = 1
 endif
 
 ifndef GZIP_BUILD_IMAGE
-export GZIP_BUILD_IMAGE = 0
+export GZIP_BUILD_IMAGE = 1
 endif
 
 ifndef GEN_BIN_IMAGE


### PR DESCRIPTION
### Description
- enabling GZIP build images by default
- check if .gz image file exists 
  - If exists, then use it instead for the rogue_XXX.zip
- force the extension to be exact
  - Previously only declaring `.mcs` would grab both `.mcs` and the `.mcs.gz`
  - $ indicates "end of the string"
- prevent file duplication writes in the zipFile
  - Example: declaring both `.mcs` and `mcs.gz` in the releases.yaml