### PR TITLE
Release script tweaks

### DIFF
--- a/releaseGen.py
+++ b/releaseGen.py
@@ -131,6 +131,14 @@ def getVersion():
 
     return ver, prev
 
+def releaseType(ver):
+    parts = str.split(ver.replace('v', ''), '.')
+    if parts[-1] != '0':
+        return 'Patch'
+    if parts[-2] != '0':
+        return 'Minor'
+    return 'Major'
+
 def selectRelease(cfg):
     relName = args.release
 
@@ -497,10 +505,10 @@ def pushRelease(cfg, relName, relData, ver, tagAttach, prev):
     # Check if this is a primary release
     if relData['Primary']:
         tag = f'{ver}'
-        msg = f'version {ver} Release'
+        msg = f'{releaseType(ver)} Release {ver}'
     else:
         tag = f'{relName}_{ver}'
-        msg = f'{relName} version {ver} Release'
+        msg = f'{relName} {releaseType(ver)} Release {ver}'
 
     print("\nLogging into github....\n")
 

--- a/releaseNotes.py
+++ b/releaseNotes.py
@@ -71,7 +71,9 @@ def getReleaseNotes(locRepo, remRepo, tagRange, noSort=False):
             else:
                 entry['Jira'] = None
 
-            records.append(entry)
+            if 'release candidate' not in req.title.lower():
+                records.append(entry)
+                
             entry = {}         
             
     # Check if sorting the pull request entries        
@@ -188,9 +190,9 @@ if __name__ == "__main__":
     print(md)
 
     if args.copy:
-        try:	
-            pyperclip.copy(md)	
-            print('Release notes copied to clipboard')	
-        except:	
+        try:
+            pyperclip.copy(md)
+            print('Release notes copied to clipboard')
+        except:
             print("Copy to clipboard failed!")
 


### PR DESCRIPTION
In releaseGen.py, the tag message is now like this:
```
Major Release vX.0.0
Minor Release vX.Y.0
Patch Release vX.Y.Z
```

The releaseNotes.py script has also been tweaked to omit any "Release Candidate" PRs from the generated release notes, as these are unnecessary to include.