### PR TITLE
prevent adding duplicate loadZipIpCore

### DIFF
--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -107,6 +107,7 @@ set_msg_config -id {Synth 8-3512}     -new_severity ERROR;# SYNTH: Assigned valu
 set_msg_config -id {Synth 8-327}      -new_severity ERROR;# SYNTH: Inferred latch
 set_msg_config -id {VRFC 10-664}      -new_severity ERROR;# SIM:   expression has XXX elements ; expected XXX
 set_msg_config -id {filemgmt 20-1318} -new_severity ERROR;# FILEMGMT: Duplicate entities/files found in the same library
+set_msg_config -id {IP_Flow 19-1663}  -new_severity ERROR;# IP_FLOW: Duplicate IP found
 
 ## Check for version 2015.3 (or older)
 if { [VersionCompare 2015.3] <= 0 } {

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -1720,8 +1720,11 @@ proc loadZipIpCore args {
             set fileExt [file extension $params(path)]
             if { ${fileExt} eq {.zip} ||
                  ${fileExt} eq {.ZIP} } {
-               # Add achieved .zip to repo path
-               update_ip_catalog -add_ip $params(path) -repo_path $params(repo_path)
+               # Check if directory doesn't exist yet
+               if { [file exists [file rootname "$params(repo_path)/$params(path)"]] == 0 } {
+                  # Add achieved .zip to repo path
+                  # update_ip_catalog -add_ip $params(path) -repo_path $params(repo_path)
+               }
             } else {
                puts "\n\n\n\n\n********************************************************"
                puts "loadZipIpCore: $params(path) does not have a \[.zip,.ZIP\] file extension"
@@ -1747,8 +1750,11 @@ proc loadZipIpCore args {
             if { ${list} != "" } {
                # Load all the constraint files
                foreach pntr ${list} {
-                  # Add achieved .zip to repo path
-                  update_ip_catalog -add_ip ${pntr} -repo_path $params(repo_path)
+                  # Check if directory doesn't exist yet
+                  if { [file exists [file rootname "$params(repo_path)/${pntr}"]] == 0 } {
+                     # Add achieved .zip to repo path
+                     # update_ip_catalog -add_ip ${pntr} -repo_path $params(repo_path)
+                  }
                }
             } else {
                puts "\n\n\n\n\n********************************************************"


### PR DESCRIPTION
### Description
- Bug fix for duplicated IP cores loaded when you load your design more than one time after a make clean
- Changed `[IP_Flow 19-1663] Duplicate IP found` from `warning` to `error`