### PR TITLE
Add missing f-strings in firmwareRelease.py

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -554,8 +554,8 @@ def pushRelease(cfg, relName, relData, ver, tagAttach, prev):
             relOld = prev
             relNew = ver
         else:
-            relOld = '{relName}_{prev}'
-            relNew = '{relName}_{ver}'
+            relOld = f'{relName}_{prev}'
+            relNew = f'{relName}_{ver}'
 
         print("\nGenerating release notes ...")
         md = releaseNotes.getReleaseNotes(git.Git(gitDir), remRepo, oldTag=relOld, newTag=relNew)

--- a/scripts/releaseNotes.py
+++ b/scripts/releaseNotes.py
@@ -22,7 +22,7 @@ import re
 def getReleaseNotes(locRepo, remRepo, oldTag, newTag):
 
     # Get logs
-    loginfo = locRepo.log(f"{oldTag}...{newTag}", '--grep', "\"Merge pull request\"")
+    loginfo = locRepo.log(f"{oldTag}...{newTag}", '--grep', "Merge pull request")
 
     # Grouping of recors
     records = odict({'Bug': [],

--- a/scripts/releaseNotes.py
+++ b/scripts/releaseNotes.py
@@ -22,7 +22,7 @@ import re
 def getReleaseNotes(locRepo, remRepo, oldTag, newTag):
 
     # Get logs
-    loginfo = locRepo.log(f"{oldTag}...{newTag}", '--grep', 'Merge pull request')
+    loginfo = locRepo.log(f"{oldTag}...{newTag}", '--grep', "\"Merge pull request\"")
 
     # Grouping of recors
     records = odict({'Bug': [],


### PR DESCRIPTION
Two strings in `firmwareRelease.py` should have been f-strings for string substitution. This is now fixed.