### PR TITLE
Make leading v optional in version number

### DIFF
--- a/scripts/releaseGen.py
+++ b/scripts/releaseGen.py
@@ -29,7 +29,7 @@ if newTag is None:
     exit("TRAVIS_TAG not in environment.")
 
 # Check tag to make sure it is a proper release: va.b.c
-vpat = re.compile('v\d+\.\d+\.\d+')
+vpat = re.compile('v?\d+\.\d+\.\d+')
 
 if vpat.match(newTag) is None:
     exit("Not a release version")


### PR DESCRIPTION
Some repos don't use the vx.x.x format.