### PR TITLE
Avoid yaml loader deprecation error

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -101,7 +101,7 @@ def loadReleaseConfig():
     try:
         with open(relFile) as f:
             txt = f.read()
-            cfg = yaml.load(txt)
+            cfg = yaml.load(txt,Loader=yaml.Loader)
     except Exception as e:
         raise Exception(f"Failed to load project release file {relFile}: {e}")
 


### PR DESCRIPTION
See 

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

for more information. We will use the unsafe loader.