### PR TITLE
release candidate v2.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ firmware/common/python/
 *.hdf
 *.vho
 *.zip
+*.xsa


### PR DESCRIPTION
### Description
- Updated `.gitignore` template
  - Ignoring Vivado 2020 .xsa files
- Fixed the bug where VCS won't compile if you have a purely VHDL simulation #194