### PR TITLE
Update firmwareRelease.py

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -624,12 +624,7 @@ if __name__ == "__main__":
 
     # Determine if we generate a Rogue zipfile
     if 'Rogue' in relData['Types']:
-
-        if relData['Primary']:
-            zipName = os.path.join(os.getcwd(),f'rogue_{ver}.zip')
-        else:
-            zipName = os.path.join(os.getcwd(),f'rogue_{relName}_{ver}.zip')
-
+        zipName = os.path.join(os.getcwd(),f'rogue_{relName}_{ver}.zip')
         buildRogueFile(zipName,cfg,ver,relName,relData,imgList)
         tagAttach.append(zipName)
 


### PR DESCRIPTION
### Description
- Updating zipName for rogue to always be rogue_{relName}_{ver}.zip
  - This will break some of the .travis.yml for `DOWNLOAD_URL` variables