### PR TITLE
adding versal support

### DIFF
--- a/vivado/gui.tcl
+++ b/vivado/gui.tcl
@@ -19,7 +19,11 @@ source -quiet $::env(RUCKUS_DIR)/vivado/properties.tcl
 source -quiet $::env(RUCKUS_DIR)/vivado/messages.tcl
 
 # Update the bitstream post script
-set_property STEPS.WRITE_BITSTREAM.TCL.POST ${RUCKUS_DIR}/vivado/post_route_run.tcl [get_runs impl_1]
+if { [isVersal] } {
+   set_property STEPS.WRITE_DEVICE_IMAGE.TCL.POST ${RUCKUS_DIR}/vivado/post_route_run.tcl [get_runs impl_1]
+} else {
+   set_property STEPS.WRITE_BITSTREAM.TCL.POST ${RUCKUS_DIR}/vivado/post_route_run.tcl [get_runs impl_1]
+}
 
 # Call the user script
 SourceTclFile ${VIVADO_DIR}/gui.tcl

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -98,6 +98,20 @@ proc getFpgaFamily { } {
    return [get_property FAMILY [get_property {PART} [current_project]]]
 }
 
+## Returns the FPGA family string
+proc getFpgaArch { } {
+   return [get_property ARCHITECTURE [get_property {PART} [current_project]]]
+}
+
+## Returns true is Versal
+proc isVersal { } {
+   if { [getFpgaArch] != "versal" } {
+      return false;
+   } else {
+      return true;
+   }
+}
+
 ## Get the number of CPUs available on the Linux box
 proc GetCpuNumber { } {
    return [exec cat /proc/cpuinfo | grep processor | wc -l]

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -230,7 +230,11 @@ proc CopyIpCores { {copyDcp true} {copySourceCode false} } {
                # Check if copying .DCP output
                if { ${copyDcp} } {
                   # Overwrite the existing .dcp file in the source tree
-                  set SRC [string map {.xci .dcp} ${SRC}]
+                  if { $::env(VIVADO_VERSION) >= 2020.2 } {
+                     set SRC "${OUT_DIR}/${VIVADO_PROJECT}.runs/${corePntr}_synth_1/${corePntr}.dcp"
+                  } else {
+                     set SRC [string map {.xci .dcp} ${SRC}]
+                  }
                   set DST [string map {.xci .dcp} ${DST}]
                   exec cp ${SRC} ${DST}
                   puts "exec cp ${SRC} ${DST}"

--- a/vivado/properties.tcl
+++ b/vivado/properties.tcl
@@ -27,7 +27,11 @@ set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE ${RUCKUS_DIR}/vivado/mess
 set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE             ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
 set_property STEPS.ROUTE_DESIGN.TCL.PRE                ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
 set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
-set_property STEPS.WRITE_BITSTREAM.TCL.PRE             ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
+if { [isVersal] } {
+   set_property STEPS.WRITE_DEVICE_IMAGE.TCL.PRE       ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
+} else {
+   set_property STEPS.WRITE_BITSTREAM.TCL.PRE          ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
+}
 
 # Refer to http://www.xilinx.com/support/answers/65415.html
 if { [VersionCompare 2016.1] >= 0 } {


### PR DESCRIPTION
### Description
- Update for Versal support
  - Versal production add in Vivado 2020.2
- IP core .DCP no longer dump in source_1/ip dir in Vivado 2020.2