### PR TITLE
Vivado 2020.3 Support

### DIFF
--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -545,7 +545,7 @@ proc CheckVivadoVersion { } {
       return -code error
    }
    # Check if version is newer than what official been tested
-   if { [VersionCompare 2020.2.0] > 0 } {
+   if { [VersionCompare 2020.3.0] > 0 } {
       puts "\n\n\n\n\n********************************************************"
       puts "ruckus has NOT been regression tested with this Vivado $::env(VIVADO_VERSION) release yet"
       puts "https://confluence.slac.stanford.edu/x/n4-jCg"


### PR DESCRIPTION
### Description
- Vivado 2020.3 is a `versal device only` release
- Verified 2020.3 Versal support on my edgeML dev git project still works