### PR TITLE
Release Candidate v3.0.2

### DIFF
--- a/vivado/build.tcl
+++ b/vivado/build.tcl
@@ -74,7 +74,7 @@ set syn_rc [catch {
    if { [CheckSynth] != true } {
       ## Check for DCP only synthesis run
       if { [info exists ::env(SYNTH_DCP)] } {
-         set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
+         SetSynthOutOfContext
       }
       ## Launch the run
       launch_runs synth_1 -jobs $::env(PARALLEL_SYNTH)

--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -160,7 +160,7 @@ set_msg_config -id {Opt 31-80}      -new_severity ERROR;# IMPL: Multi-driver net
 set_msg_config -id {Route 35-14}    -new_severity ERROR;# IMPL: Multi-driver net found in the design
 set_msg_config -id {AVAL-46}        -new_severity ERROR;# DRC: MMCM's (or PLL's) VCO frequency out of range
 if { ${notTig} } {
-   set_msg_config -id {Route 35-39}    -new_severity ERROR;# IMPL: The design did not meet timing requirements
+   # set_msg_config -id {Route 35-39}    -new_severity ERROR;# IMPL: The design did not meet timing requirements
    set_msg_config -id {Timing 38-282}  -new_severity ERROR;# IMPL: The design failed to meet the timing requirements
 }
 

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -167,6 +167,11 @@ proc ::findFiles { baseDir pattern } {
    return $files
 }
 
+## Set the synthesis to "out of context"
+proc SetSynthOutOfContext { } {
+   set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
+}
+
 ## Function to build all the IP cores
 proc BuildIpCores { } {
    # Get variables

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -545,7 +545,7 @@ proc CheckVivadoVersion { } {
       return -code error
    }
    # Check if version is newer than what official been tested
-   if { [VersionCompare 2020.2.0] > 0 } {
+   if { [VersionCompare 2020.3.0] > 0 } {
       puts "\n\n\n\n\n********************************************************"
       puts "ruckus has NOT been regression tested with this Vivado $::env(VIVADO_VERSION) release yet"
       puts "https://confluence.slac.stanford.edu/x/n4-jCg"


### PR DESCRIPTION
### Description
- Vivado 2020.3 Support #225
- move setting synthesis to out_of_context to a new proc() command #227
- vivado/messages.tcl: Commenting Out {Route 35-39} #228