### PR TITLE
adding netname list range support to ConfigProbe()

### DIFF
--- a/vivado/proc/debug_probes.tcl
+++ b/vivado/proc/debug_probes.tcl
@@ -43,13 +43,18 @@ proc GetCurrentProbe {ilaName} {
 }
 
 ## Probe Configuring function
-proc ConfigProbe {ilaName netName} {
+proc ConfigProbe {ilaName netName {lsb 0} {msb -1} } {
 
    # determine the probe index
    set probeIndex ${ilaName}/probe[expr [llength [get_debug_ports ${ilaName}/probe*]] - 1]
 
    # get the list of netnames
    set probeNet [lsort -increasing -dictionary [get_nets ${netName}]]
+
+   # Check if using range of values
+   if { ${msb} > -1 } {
+      set probeNet [lrange ${probeNet} ${lsb} ${msb}]
+   }
 
    # calculate the probe width
    set probeWidth [llength ${probeNet}]


### PR DESCRIPTION
### Description
- Allow the user to select the range in the netlist values

### Example
- If I don't set the range, I get all values in the wildcard list
  - Result: `tData[511:0]` (512 values)
```tcl
ConfigProbe ${ilaName} {U_Hsio/U_CXP/U_Core/U_Rx/U_Mux/r[rxMaster][tData][*]}
```
- I can use the range to only add probes to bits 0 through 127
  - Result: `tData[127:0]` (127values)
```tcl
ConfigProbe ${ilaName} {U_Hsio/U_CXP/U_Core/U_Rx/U_Mux/r[rxMaster][tData][*]} 0 127
```