### PR TITLE
xsim.tcl: remove top-level re-definition that seems to break the xsim Makefile rule + xsim-dev merge

### DIFF
--- a/vivado/xsim.tcl
+++ b/vivado/xsim.tcl
@@ -53,10 +53,6 @@ export_ip_user_files -no_script
 ########################################################
 set sim_rc [catch {
 
-   # Set sim properties
-   set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
-   set_property top_lib xil_defaultlib [get_filesets sim_1]
-
    # Launch the xsim
    launch_simulation
 


### PR DESCRIPTION
As exercised in [this commit first](https://github.com/slaclab/snl-trans-FES/commit/3b8c21cd7aad925749e817a86fb5f7f13e30ef34), and [also this one](b121ba3562eeb5780d7a54c0a936082cb244679d), the command `$ make xsim` produces a valid XSIM result.

The said commit from the repo linked avove points to the ruckus commit/branch that is to be merged with this request.

Rolling back the changes of the `xsim.tcl` script shows that there was an issue with re-defining the top-level of the simulation design.