### PR TITLE
Added ModelSim/Questa simulation support

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -368,7 +368,7 @@ vcs : $(SOURCE_DEPEND)
 	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/vcs.tcl
 
 ###############################################################
-#### Vivado VCS Simulation ####################################
+#### Vivado Questa Simulation #################################
 ###############################################################
 .PHONY : qsim
 qsim : $(SOURCE_DEPEND)

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -368,7 +368,7 @@ vcs : $(SOURCE_DEPEND)
 	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/vcs.tcl
 
 ###############################################################
-#### Vivado Questa Simulation #################################
+#### Vivado ModelSim/Questa Simulation #################################
 ###############################################################
 .PHONY : msim
 msim : $(SOURCE_DEPEND)

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -368,6 +368,14 @@ vcs : $(SOURCE_DEPEND)
 	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/vcs.tcl
 
 ###############################################################
+#### Vivado VCS Simulation ####################################
+###############################################################
+.PHONY : qsim
+qsim : $(SOURCE_DEPEND)
+	$(call ACTION_HEADER,"Questa Simulation")
+	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/qsim.tcl
+
+###############################################################
 #### Vivado Batch Mode within the Project Environment  ########
 ###############################################################
 .PHONY : batch

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -370,10 +370,10 @@ vcs : $(SOURCE_DEPEND)
 ###############################################################
 #### Vivado Questa Simulation #################################
 ###############################################################
-.PHONY : qsim
-qsim : $(SOURCE_DEPEND)
-	$(call ACTION_HEADER,"Questa Simulation")
-	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/qsim.tcl
+.PHONY : msim
+msim : $(SOURCE_DEPEND)
+	$(call ACTION_HEADER,"ModelSim/Questa Simulation")
+	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/msim.tcl
 
 ###############################################################
 #### Vivado Batch Mode within the Project Environment  ########

--- a/vivado/msim.tcl
+++ b/vivado/msim.tcl
@@ -8,8 +8,8 @@
 ## the terms contained in the LICENSE.txt file.
 ##############################################################################
 
-## \file vivado/qsim.tcl
-# \brief This script performs a Questa simulation
+## \file vivado/msim.tcl
+# \brief This script performs a Modelsim/Questa simulation
 
 # Get variables and procedures
 source -quiet $::env(RUCKUS_DIR)/vivado/env_var.tcl
@@ -19,48 +19,62 @@ source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
 ## Procedures and Checks
 #####################################################################################################
 
-## Get Questa install name
-proc GetQuestaName { } {
+## Get ModelSim/Questa install name
+proc GetModelsim-QuestaName { } {
 
-    # Get the Questa version
+    # Get the ModelSim/Questa version
     set err_ret [catch {
-        exec bash -c "command -v $::env(QSIM_PATH)/vsim"
+        exec bash -c "command -v $::env(MSIM_PATH)/vsim"
     } grepCmd]
 
     if { ${err_ret} != 0} {
         puts "\n\n*********************************************************"
         puts "vsim: Command not found."
-        puts "Please setup QSIM_PATH in your Questa setup script"
-        puts "Example: export QSIM_PATH=/tools/questasim/bin"
+        puts "Please setup MSIM_PATH in your Modelsim/Questa setup script"
+        puts "Example: export MSIM_PATH=/tools/questasim/bin"
         puts "*********************************************************\n\n"
         exit -1
     }
 
     set err_ret [catch {
-        exec $::env(QSIM_PATH)/vsim -version
+        exec $::env(MSIM_PATH)/vsim -version
     } grepVersion]
 
-    scan $grepVersion "Questa Sim-64 vsim %s Simulator%s" VersionNumber blowoff
+    if {[string first "Questa" ${grepVersion}] != -1} {
+        set Simulator "Questa"
+    } elseif {[string first "ModelSim" ${grepVersion}] != -1} {
+        set Simulator "ModelSim"
+    } else {
+        puts "\n\n*********************************************************"
+        puts "Simulator not found."
+        puts "*********************************************************\n\n"
+        exit -1
+    }
 
-    return ${VersionNumber}
+    while {[scan $grepVersion %s%n word length] == 2 && $word != {vsim}} {set grepVersion [string range $grepVersion $length end]}
+    scan $grepVersion "%s %s Simulator%s" blowoff1 VersionNumber blowoff2
+
+    return [list ${Simulator} ${VersionNumber}]
 }
 
-## Checks for Questa Sim versions that ruckus supports
-proc QuestaVersionCheck { } {
+## Checks for ModelSim/Questa Sim versions that ruckus supports
+proc Modelsim-QuestaVersionCheck { } {
     set retVar -1
 
-    # List of supported QuestaSim versions
-    set supported "2021.1_2"
+    # List of supported ModelSim/QuestaSim versions
+    set supported "2019.2 2021.1_2"
 
     # Get Version Name
-    set VersionNumber [GetQuestaName]
+    set SimInfo [GetModelsim-QuestaName]
+    set Simulator [lindex $SimInfo 0]
+    set VersionNumber [lindex $SimInfo 1]
 
     # Generate error message
     set errMsg "\n\n*********************************************************\n"
-    set errMsg "${errMsg}Your Questa Sim Version   = ${VersionNumber}\n"
-    set errMsg "${errMsg}However, Questa Sim Version Lock = ${supported}\n"
-    set errMsg "${errMsg}You need to change your Questa Sim software to one of these versions\n"
-    set errMsg "${errMsg}*********************************************************\n\n"
+    set errMsg "${errMsg}Your ${Simulator} version   = ${VersionNumber}\n"
+    set errMsg "${errMsg}However, supported ${Simulator} version = ${supported}\n"
+    set errMsg "${errMsg}You should change your ${Simulator} software to one of these versions\n"
+    set errMsg "${errMsg}*********************************************************\n"
 
     # Loop through the different support version list
     foreach pntr ${supported} {
@@ -78,7 +92,7 @@ proc QuestaVersionCheck { } {
 }
 
 #####################################################################################################
-## Open project and some Questa Sim checking
+## Open project and some ModelSim/Questa Sim checking
 #####################################################################################################
 
 # Check for version 2016.4 (or later)
@@ -87,9 +101,15 @@ if { [VersionCheck 2016.4] < 0 } {
     exit -1
 }
 
-# Check for supported Questa version
-if { [QuestaVersionCheck] < 0 } {
-    exit -1
+# Check for supported ModelSim/Questa version
+if { [Modelsim-QuestaVersionCheck] < 0 } {
+    #exit -1
+    puts -nonewline "Sim version not supported, do you want to continue? (y/n): "
+    flush stdout
+    set Cont [gets stdin]
+    if { ${Cont} == "n" } {
+        exit -1
+    }
 }
 
 # Open the project
@@ -100,43 +120,46 @@ if { [CheckPrjConfig sim_1] != true } {
     exit -1
 }
 
-# Target specific Questa script
-SourceTclFile ${VIVADO_DIR}/pre_qsim.tcl
+# Target specific ModelSim/Questa script
+SourceTclFile ${VIVADO_DIR}/pre_msim.tcl
 
 #####################################################################################################
 ## Set the local variables
 #####################################################################################################
 
 # Setup variables
-set VersionNumber [GetQuestaName]
-set simLibOutDir ${VIVADO_INSTALL}/qsim-${VersionNumber}
+
+set SimInfo [GetModelsim-QuestaName]
+set Simulator [lindex $SimInfo 0]
+set VersionNumber [lindex $SimInfo 1]
+set simLibOutDir ${VIVADO_INSTALL}/msim-${VersionNumber}
 
 #####################################################################################################
-## Compile the Questa Simulation Library
+## Compile the ModelSim/Questa Simulation Library
 #####################################################################################################
 
-# Compile the libraries for Questa Sim
+# Compile the libraries for ModelSim/Questa Sim
 if { [file exists ${simLibOutDir}] != 1 } {
 
     # Make the directory
     exec mkdir -p ${simLibOutDir}
 
     # Compile the simulation libraries
-    set CompSimLibComm "compile_simlib -simulator questa -simulator_exec_path {$::env(QSIM_PATH)} -family all -language all -library all -dir ${simLibOutDir}"
+    set CompSimLibComm "compile_simlib -simulator [string tolower ${Simulator}] -simulator_exec_path {$::env(MSIM_PATH)} -family all -language all -library all -dir ${simLibOutDir}"
     eval ${CompSimLibComm}
 }
 
 
-#####################################################################################################
-## Setup Vivado's Questa environment
+####################################################################################################
+## Setup Vivado's ModelSim/Questa environment
 #####################################################################################################
 
-# Set Questa as target_simulator
-set_property target_simulator "Questa" [current_project]
-set_property compxlib.questa_compiled_library_dir ${simLibOutDir} [current_project]
+# Set target_simulator
+set_property target_simulator "${Simulator}" [current_project]
+set_property compxlib.[string tolower ${Simulator}]_compiled_library_dir ${simLibOutDir} [current_project]
 
-# Configure Questa settings
-set VIVADO_PROJECT_SIM_TIME "set_property -name {questa.simulate.runtime} -value {$::env(VIVADO_PROJECT_SIM_TIME)} -objects \[\get_filesets \sim_1\]"
+# Configure ModelSim/Questa settings
+set VIVADO_PROJECT_SIM_TIME "set_property -name {[string tolower ${Simulator}].simulate.runtime} -value {$::env(VIVADO_PROJECT_SIM_TIME)} -objects \[\get_filesets \sim_1\]"
 eval ${VIVADO_PROJECT_SIM_TIME}
 set_property nl.process_corner fast [get_filesets sim_1]
 set_property unifast true [get_filesets sim_1]
@@ -157,7 +180,7 @@ foreach filePntr ${fileList} {
 ## Run Questa simulation
 #####################################################################################################
 set errMsg "\n\n*********************************************************\n"
-   set errMsg "${errMsg}Error in Questa Simulation. Check the errors in the console\n"
+set errMsg "${errMsg}Error in ${Simulator}. Check the errors in the console\n"
    set errMsg "${errMsg}*********************************************************\n\n"
 
 set sim_rc [catch {
@@ -166,8 +189,8 @@ set sim_rc [catch {
     set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
     set_property top_lib xil_defaultlib [get_filesets sim_1]
 
-    # Launch the xsim
-    launch_simulation -install_path $::env(QSIM_PATH)
+    # Launch the msim
+    launch_simulation -install_path $::env(MSIM_PATH)
 
 } _SIM_RESULT]
 

--- a/vivado/msim.tcl
+++ b/vivado/msim.tcl
@@ -36,7 +36,8 @@ proc GetModelsim-QuestaName { } {
         if { ${err_ret} != 0} {
             puts "\n\n*********************************************************"
             puts "vsim: Command not found."
-            puts "Please setup MSIM_PATH in your Modelsim/Questa setup script"
+            puts "Please add ModelSim/Questa installation directory to your PATH"
+            puts "or setup MSIM_PATH variable in your Modelsim/Questa setup script"
             puts "Example: export MSIM_PATH=/tools/questasim/bin"
             puts "*********************************************************\n\n"
             exit -1
@@ -138,6 +139,9 @@ SourceTclFile ${VIVADO_DIR}/pre_msim.tcl
 #####################################################################################################
 ## Set the local variables
 #####################################################################################################
+
+# Setup variables
+
 set SimInfo [GetModelsim-QuestaName]
 set Simulator [lindex $SimInfo 0]
 set VersionNumber [lindex $SimInfo 1]
@@ -147,13 +151,15 @@ set simLibOutDir ${VIVADO_INSTALL}/msim-${VersionNumber}
 #####################################################################################################
 ## Compile the Questa Simulation Library
 #####################################################################################################
+
+# Compile the libraries for ModelSim/Questa Sim
 if { [file exists ${simLibOutDir}] != 1 } {
 
     # Make the directory
     exec mkdir -p ${simLibOutDir}
 
     # Compile the simulation libraries
-    set CompSimLibComm "compile_simlib -simulator [string tolower ${Simulator}] -simulator_exec_path { ${MSIM_PATH} } -family all -language all -library all -dir ${simLibOutDir}"
+    set CompSimLibComm "compile_simlib -simulator [string tolower ${Simulator}] -simulator_exec_path ${MSIM_PATH} -family all -language all -library all -dir ${simLibOutDir}"
     eval ${CompSimLibComm}
 }
 

--- a/vivado/qsim.tcl
+++ b/vivado/qsim.tcl
@@ -115,15 +115,17 @@ set simLibOutDir ${VIVADO_INSTALL}/qsim-${VersionNumber}
 ## Compile the Questa Simulation Library
 #####################################################################################################
 
-# Compile the libraries for VCS
+# Compile the libraries for Questa Sim
 if { [file exists ${simLibOutDir}] != 1 } {
 
-   # Make the directory
-   exec mkdir ${simLibOutDir}
+    # Make the directory
+    exec mkdir -p ${simLibOutDir}
 
-   # Compile the simulation libraries
-   catch { compile_simlib -force -simulator questa -family all -language all -library all -directory ${simLibOutDir} }
+    # Compile the simulation libraries
+    set CompSimLibComm "compile_simlib -simulator questa -simulator_exec_path {$::env(QSIM_PATH)} -family all -language all -library all -dir ${simLibOutDir}"
+    eval ${CompSimLibComm}
 }
+
 
 #####################################################################################################
 ## Setup Vivado's VCS environment
@@ -154,6 +156,10 @@ foreach filePntr ${fileList} {
 #####################################################################################################
 ## Run Questa simulation
 #####################################################################################################
+set errMsg "\n\n*********************************************************\n"
+   set errMsg "${errMsg}Error in Questa Simulation. Check the errors in the console\n"
+   set errMsg "${errMsg}*********************************************************\n\n"
+
 set sim_rc [catch {
 
     # Set sim properties
@@ -169,8 +175,6 @@ set sim_rc [catch {
 # Check for error return code during the process
 ########################################################
 if { ${sim_rc} } {
-    puts "\n\n*********************************************************"
-    puts "Error in Questa Simulation. Check the errors in the console"
-    puts "*********************************************************\n\n"
+    puts ${errMsg}
     exit -1
 }

--- a/vivado/qsim.tcl
+++ b/vivado/qsim.tcl
@@ -1,0 +1,176 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+## \file vivado/qsim.tcl
+# \brief This script performs a Questa simulation
+
+# Get variables and procedures
+source -quiet $::env(RUCKUS_DIR)/vivado/env_var.tcl
+source -quiet $::env(RUCKUS_DIR)/vivado/proc.tcl
+
+#####################################################################################################
+## Procedures and Checks
+#####################################################################################################
+
+## Get Questa install name
+proc GetQuestaName { } {
+
+    # Get the Questa version
+    set err_ret [catch {
+        exec bash -c "command -v $::env(QSIM_PATH)/vsim"
+    } grepCmd]
+
+    if { ${err_ret} != 0} {
+        puts "\n\n*********************************************************"
+        puts "vsim: Command not found."
+        puts "Please setup QSIM_PATH in your Questa setup script"
+        puts "Example: export QSIM_PATH=/tools/questasim/bin"
+        puts "*********************************************************\n\n"
+        exit -1
+    }
+
+    set err_ret [catch {
+        exec $::env(QSIM_PATH)/vsim -version
+    } grepVersion]
+
+    scan $grepVersion "Questa Sim-64 vsim %s Simulator%s" VersionNumber blowoff
+
+    return ${VersionNumber}
+}
+
+## Checks for Questa Sim versions that ruckus supports
+proc QuestaVersionCheck { } {
+    set retVar -1
+
+    # List of supported VCS versions
+    set supported "2021.1_2"
+
+    # Get Version Name
+    set VersionNumber [GetQuestaName]
+
+    # Generate error message
+    set errMsg "\n\n*********************************************************\n"
+    set errMsg "${errMsg}Your Questa Sim Version   = ${VersionNumber}\n"
+    set errMsg "${errMsg}However, Questa Sim Version Lock = ${supported}\n"
+    set errMsg "${errMsg}You need to change your Questa Sim software to one of these versions\n"
+    set errMsg "${errMsg}*********************************************************\n\n"
+
+    # Loop through the different support version list
+    foreach pntr ${supported} {
+        if { ${VersionNumber} == ${pntr} } {
+            set retVar 0
+        }
+    }
+
+    # Check for no support version detected
+    if { ${retVar} < 0 } {
+        puts ${errMsg}
+    }
+
+    return ${retVar}
+}
+
+#####################################################################################################
+## Open project and some Questa Sim checking
+#####################################################################################################
+
+# Check for version 2016.4 (or later)
+if { [VersionCheck 2016.4] < 0 } {
+    close_project
+    exit -1
+}
+
+# Check for supported VCS version
+if { [QuestaVersionCheck] < 0 } {
+    exit -1
+}
+
+# Open the project
+open_project -quiet ${VIVADO_PROJECT}
+
+# Check project configuration for errors
+if { [CheckPrjConfig sim_1] != true } {
+    exit -1
+}
+
+# Target specific VCS script
+SourceTclFile ${VIVADO_DIR}/pre_qsim.tcl
+
+#####################################################################################################
+## Set the local variables
+#####################################################################################################
+
+# Setup variables
+set VersionNumber [GetQuestaName]
+set simLibOutDir ${VIVADO_INSTALL}/qsim-${VersionNumber}
+
+#####################################################################################################
+## Compile the Questa Simulation Library
+#####################################################################################################
+
+# Compile the libraries for VCS
+if { [file exists ${simLibOutDir}] != 1 } {
+
+   # Make the directory
+   exec mkdir ${simLibOutDir}
+
+   # Compile the simulation libraries
+   catch { compile_simlib -force -simulator questa -family all -language all -library all -directory ${simLibOutDir} }
+}
+
+#####################################################################################################
+## Setup Vivado's VCS environment
+#####################################################################################################
+
+# Set Questa as target_simulator
+set_property target_simulator "Questa" [current_project]
+set_property compxlib.questa_compiled_library_dir ${simLibOutDir} [current_project]
+
+# Configure Questa settings
+set VIVADO_PROJECT_SIM_TIME "set_property -name {questa.simulate.runtime} -value {$::env(VIVADO_PROJECT_SIM_TIME)} -objects \[\get_filesets \sim_1\]"
+eval ${VIVADO_PROJECT_SIM_TIME}
+set_property nl.process_corner fast [get_filesets sim_1]
+set_property unifast true [get_filesets sim_1]
+
+# Update the compile order
+update_compile_order -quiet -fileset sim_1
+
+# Check for mixed-simulation
+set fileList [get_files -compile_order sources -used_in simulation]
+set mixedSim false
+foreach filePntr ${fileList} {
+   if { [file extension ${filePntr}] ne {.vhd} } {
+      set mixedSim true
+   }
+}
+
+#####################################################################################################
+## Run Questa simulation
+#####################################################################################################
+set sim_rc [catch {
+
+    # Set sim properties
+    set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
+    set_property top_lib xil_defaultlib [get_filesets sim_1]
+
+    # Launch the xsim
+    launch_simulation -install_path $::env(QSIM_PATH)
+
+} _SIM_RESULT]
+
+########################################################
+# Check for error return code during the process
+########################################################
+if { ${sim_rc} } {
+    puts "\n\n*********************************************************"
+    puts "Error in Questa Simulation. Check the errors in the console"
+    puts "*********************************************************\n\n"
+    exit -1
+}

--- a/vivado/qsim.tcl
+++ b/vivado/qsim.tcl
@@ -49,7 +49,7 @@ proc GetQuestaName { } {
 proc QuestaVersionCheck { } {
     set retVar -1
 
-    # List of supported VCS versions
+    # List of supported QuestaSim versions
     set supported "2021.1_2"
 
     # Get Version Name
@@ -87,7 +87,7 @@ if { [VersionCheck 2016.4] < 0 } {
     exit -1
 }
 
-# Check for supported VCS version
+# Check for supported Questa version
 if { [QuestaVersionCheck] < 0 } {
     exit -1
 }
@@ -100,7 +100,7 @@ if { [CheckPrjConfig sim_1] != true } {
     exit -1
 }
 
-# Target specific VCS script
+# Target specific Questa script
 SourceTclFile ${VIVADO_DIR}/pre_qsim.tcl
 
 #####################################################################################################

--- a/vivado/qsim.tcl
+++ b/vivado/qsim.tcl
@@ -128,7 +128,7 @@ if { [file exists ${simLibOutDir}] != 1 } {
 
 
 #####################################################################################################
-## Setup Vivado's VCS environment
+## Setup Vivado's Questa environment
 #####################################################################################################
 
 # Set Questa as target_simulator

--- a/vivado/xsim.tcl
+++ b/vivado/xsim.tcl
@@ -45,7 +45,7 @@ if { [CheckPrjConfig sim_1] != true } {
 ########################################################
 ## Prepare simulation and check IP cores
 ########################################################
-generate_target {simulation} [get_ips]
+generate_target -quiet {simulation} [get_ips]
 export_ip_user_files -no_script
 
 ########################################################
@@ -54,6 +54,7 @@ export_ip_user_files -no_script
 set sim_rc [catch {
 
    # Set sim properties
+   set_property target_simulator XSim [current_project]
    set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
    set_property top_lib xil_defaultlib [get_filesets sim_1]
 


### PR DESCRIPTION
Hi Larry,
I've been using ruckus for projects I've been working on (its great! Thanks for developing it), and I added support for Vivado simulation using either ModelSim or Questa.

The msim.tcl script automatically detect whether you're using ModelSim or Questa (based on either what you have on your PATH or by explicitly using an environmental variable, MSIM_PATH), and whether you need to compile or not simulation libraries and then starts the simulation (its different compared to the VCS tcl script, since here no scripts are generated, but works more like the XSim tcl script).

The only thing Im not able to figure out is an error compiling the simulation libraries. If I run the `compile_simlib` in the  "ruckus environment" I get errors, but if I ran the identical command on a separate instance of vivado in tcl mode, the command is successful..
Do you have any idea why this could happen?