### PR TITLE
Updates to createNewRepo.py

### DIFF
--- a/scripts/createNewRepo.py
+++ b/scripts/createNewRepo.py
@@ -335,17 +335,9 @@ def setupNewRepoStructure(repo):
 #############################################################################################
 
 def setBranchProtection(repo):
-
-    # Create pre-release branch from main branch
-    print('Create pre-release branch from main branch...\n')
-    repo.create_git_ref(
-        ref = 'refs/heads/pre-release',
-        sha = repo.get_branch('main').commit.sha,
-    )
-
-    # Creating Setting Branch Protection for main and pre-release
-    print('Creating Setting Branch Protection for main and pre-release...\n')
-    for idx in ['main','pre-release']:
+    # Creating Setting Branch Protection for main
+    print('Creating Setting Branch Protection for main...\n')
+    for idx in ['main']:
         repo.get_branch(idx).edit_protection()
 
 #############################################################################################

--- a/scripts/createNewRepo.py
+++ b/scripts/createNewRepo.py
@@ -288,9 +288,9 @@ def setPermissions(gh,repo):
 # Team.set_repo_permission() is deprecated, use Team.update_team_repository() instead
 def updateTeamRepository(team, repo, permission):
     try:
-      team.update_team_repository(repo, permission)
+        team.update_team_repository(repo, permission)
     except:
-      team.set_repo_permission(repo, permission)
+        team.set_repo_permission(repo, permission)
 
 #############################################################################################
 

--- a/scripts/createNewRepo.py
+++ b/scripts/createNewRepo.py
@@ -263,7 +263,7 @@ def setPermissions(gh,repo):
             print( f'Team Admin Permission: {orgName}/{teamName}' )
             org = gh.get_organization(orgName)
             team = org.get_team_by_slug(teamName)
-            team.set_repo_permission(repo, 'admin')
+            updateTeamRepository(team, repo, 'admin')
 
     # Check for list of teams with write permissions
     if args.writeTeam is not None:
@@ -271,7 +271,7 @@ def setPermissions(gh,repo):
             print( f'Team Write Permission: {orgName}/{teamName}' )
             org = gh.get_organization(orgName)
             team = org.get_team_by_slug(teamName)
-            team.set_repo_permission(repo, 'push')
+            updateTeamRepository(team, repo, 'push')
 
     # Check for list of teams with read permissions
     if args.readTeam is not None:
@@ -279,9 +279,18 @@ def setPermissions(gh,repo):
             print( f'Team Read Permission: {orgName}/{teamName}' )
             org = gh.get_organization(orgName)
             team = org.get_team_by_slug(teamName)
-            team.set_repo_permission(repo, 'pull')
+            updateTeamRepository(team, repo, 'pull')
 
     print('\n')
+
+#############################################################################################
+
+# Team.set_repo_permission() is deprecated, use Team.update_team_repository() instead
+def updateTeamRepository(team, repo, permission):
+    try:
+      team.update_team_repository(repo, permission)
+    except:
+      team.set_repo_permission(repo, permission)
 
 #############################################################################################
 


### PR DESCRIPTION
### Description
- [Team.set_repo_permission() is deprecated, use Team.update_team_repository() instead](https://github.com/slaclab/ruckus/commit/64abc22765ce0e235194f4d993580a30ac4bd47f)
- [updating branch protection creation](https://github.com/slaclab/ruckus/commit/49c635c1222124a9f3d9962e6e0d1563282fab6f)