### PR TITLE
Updating make assigns to avoid freeze during build on newer versions …

### DIFF
--- a/system_shared.mk
+++ b/system_shared.mk
@@ -37,7 +37,7 @@ endif
 # Generate build string
 export BUILD_SYS_NAME    = $(shell uname -n)
 export BUILD_SVR_TYPE    = $(strip $(shell cat /etc/issue | cut -d '\' -f 1) )
-export BUILD_USER   = $(shell whoami)
+export BUILD_USER   := $(shell id -u -n)
 BUILD_DATE := $(shell date)
 BUILD_TIME := $(shell date +%Y%m%d%H%M%S)
 export BUILD_STRING = $(PROJECT): Vivado v$(VIVADO_VERSION), $(BUILD_SYS_NAME) ($(BUILD_SVR_TYPE)), Built $(BUILD_DATE) by $(BUILD_USER)

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -77,7 +77,7 @@ export VIVADO_PROJECT_SIM_TIME = 1000 ns
 endif
 
 # Synthesis Variables
-export VIVADO_VERSION   = $(shell vivado -version | grep -Po "v(\d+\.)+\d+" | cut -c2-)
+export VIVADO_VERSION   := $(shell vivado -version | grep -Po "v(\d+\.)+\d+" | cut -c2-)
 export VIVADO_INSTALL   = $(abspath  $(shell which vivado)/../..)
 export VIVADO_DIR       = $(abspath $(PROJ_DIR)/vivado)
 export VIVADO_PROJECT   = $(PROJECT)_project


### PR DESCRIPTION
Update to vivado and shared to support issue with modern version of make freezing on run.

Likely due to issue with recursion and certain shell commands https://www.spinics.net/lists/linux-trace-devel/msg11194.html, https://www.gnu.org/software/make/manual/html_node/Shell-Function.html