### PR TITLE
Remove Python Version Limit For Conda Recipes

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -336,7 +336,7 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     tmpTxt += 'requirements:\n'
     tmpTxt += '  build:\n'
     tmpTxt += '    - rogue\n'
-    tmpTxt += '    - python<3.8\n'
+    tmpTxt += '    - python\n'
     tmpTxt += '    - setuptools\n'
 
     if 'LibDir' in relData:
@@ -346,7 +346,7 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     tmpTxt += '\n'
     tmpTxt += '  host:\n'
     tmpTxt += '    - rogue\n'
-    tmpTxt += '    - python<3.8\n'
+    tmpTxt += '    - python\n'
     tmpTxt += '    - setuptools\n'
     tmpTxt += '\n'
     tmpTxt += '  run:\n'


### PR DESCRIPTION
The previous version had python locked to 3.7 which was making it hard to find solutions. This opens up the python verion.