### PR TITLE
Updating scripts/firmwareRelease.py for conda

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -369,7 +369,7 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     tmpTxt += "about:\n"
     tmpTxt += "  license: SLAC Open License\n"
     tmpTxt += "  license_file: LICENSE.txt\n"
-    tmpTxt += "\n'
+    tmpTxt += "\n"
 
     with zipFile.open('conda-recipe/meta.yaml','w') as f:
         f.write(tmpTxt.encode('utf-8'))

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -360,10 +360,10 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
     tmpTxt +=  "  host:\n"
     tmpTxt += f"    - rogue{rogueVer}\n"
-    tmpTxt +=  "    - python(pyVer}\n"
+    tmpTxt += f"    - python(pyVer}\n"
     tmpTxt +=  "\n"
     tmpTxt +=  "  run:\n"
-    tmpTxt +=  "    - python{pyVer}\n"
+    tmpTxt += f"    - python{pyVer}\n"
     tmpTxt += f"    - rogue{rogueVer}\n"
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -360,7 +360,7 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
     tmpTxt +=  "  host:\n"
     tmpTxt += f"    - rogue{rogueVer}\n"
-    tmpTxt += f"    - python(pyVer}\n"
+    tmpTxt += f"    - python{pyVer}\n"
     tmpTxt +=  "\n"
     tmpTxt +=  "  run:\n"
     tmpTxt += f"    - python{pyVer}\n"

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -322,9 +322,9 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:
         for f in cfg['CondaDependencies']:
-            if f.startswith('rogue')
+            if f.startswith('rogue'):
                 rogueDep = f
-            if f.startswith('python')
+            if f.startswith('python'):
                 pythonDep = f
 
     with zipFile.open('conda-recipe/build.sh','w') as f:

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -308,6 +308,11 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     else:
         rogueVer = ''
 
+    if 'PythonVersion' in cfg:
+        pyVer = cfg['PythonVersion']
+    else:
+        pyVer = ''
+
     # Create conda-recipe/build.sh
     tmpTxt =  '#!/usr/bin/bash\n\n'
 
@@ -355,10 +360,10 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
     tmpTxt +=  "  host:\n"
     tmpTxt += f"    - rogue{rogueVer}\n"
-    tmpTxt +=  "    - python>=3.7\n"
+    tmpTxt +=  "    - python(pyVer}\n"
     tmpTxt +=  "\n"
     tmpTxt +=  "  run:\n"
-    tmpTxt +=  "    - python>=3.7\n"
+    tmpTxt +=  "    - python{pyVer}\n"
     tmpTxt += f"    - rogue{rogueVer}\n"
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -314,7 +314,7 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
         tmpTxt += 'make -j ${CPU_COUNT}\n'
         tmpTxt += 'cd ..\n'
 
-    tmpTxt += '${PYTHON} setup.py install\n\n'
+    tmpTxt += '${PYTHON} -m pip install .\n\n'
 
     with zipFile.open('conda-recipe/build.sh','w') as f:
         f.write(tmpTxt.encode('utf-8'))
@@ -332,24 +332,24 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     tmpTxt += '\n'
     tmpTxt += 'build:\n'
     tmpTxt += '  number: 1\n'
+
+    if 'LibDir' not in relData:
+        tmpTxt += '  noarch: python\n'
+
     tmpTxt += '\n'
     tmpTxt += 'requirements:\n'
-    tmpTxt += '  build:\n'
-    tmpTxt += '    - rogue\n'
-    tmpTxt += '    - python\n'
-    tmpTxt += '    - setuptools\n'
 
     if 'LibDir' in relData:
+        tmpTxt += '  build:\n'
         tmpTxt += "    - {{ compiler('c') }}\n"
         tmpTxt += "    - {{ compiler('cxx') }}\n"
+        tmpTxt += '    - rogue\n'
 
-    tmpTxt += '\n'
     tmpTxt += '  host:\n'
-    tmpTxt += '    - rogue\n'
     tmpTxt += '    - python\n'
-    tmpTxt += '    - setuptools\n'
     tmpTxt += '\n'
     tmpTxt += '  run:\n'
+    tmpTxt += '    - python\n'
     tmpTxt += '    - rogue\n'
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:
@@ -378,7 +378,7 @@ def buildSetupPy(zipFile,ver,relName,packList,sList,relData):
 
     # setuptools version creates and installs a .egg file which will not work with
     # our image and config data! Use distutils version for now.
-    setupPy  =  "\n\nfrom distutils.core import setup\n\n"
+    setupPy  =  "\n\nfrom setuptools import setup\n\n"
     #setupPy  =  "\n\nfrom setuptools import setup\n\n"
     setupPy +=  "setup (\n"
     setupPy += f"   name='{relName}',\n"

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -303,7 +303,10 @@ def selectFiles(cfg, key):
 
 def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
-    rogueVer = cfg['RogueVersion']:
+    if 'RogueVersion' in cfg:
+        rogueVer = cfg['RogueVersion']:
+    else:
+        rogueVer = ''
 
     # Create conda-recipe/build.sh
     tmpTxt =  '#!/usr/bin/bash\n\n'

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -344,12 +344,13 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
         tmpTxt += "    - {{ compiler('c') }}\n"
         tmpTxt += "    - {{ compiler('cxx') }}\n"
         tmpTxt += '    - rogue\n'
+        tmpTxt += '\n'
 
     tmpTxt += '  host:\n'
-    tmpTxt += '    - python\n'
+    tmpTxt += '    - python>=3.7\n'
     tmpTxt += '\n'
     tmpTxt += '  run:\n'
-    tmpTxt += '    - python\n'
+    tmpTxt += '    - python>=3.7\n'
     tmpTxt += '    - rogue\n'
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -383,6 +383,19 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     with zipFile.open('conda.sh','w') as f:
         f.write(tmpTxt.encode('utf-8'))
 
+    if 'LibDir' in relData:
+
+        # Update conda_build_config.yaml
+        tmpTxt  = "pin_run_as_build:\n"
+        tmpTxt += "  rogue:\n"
+        tmpTxt += "    max_pin: x.x.x\n"
+        tmpTxt += "  python:\n"
+        tmpTxt += "    max_pin: x.x\n"
+
+        # Create conda_build_config.yaml
+        with zipFile.open('conda_build_config.yaml','w') as f:
+            f.write(tmpTxt.encode('utf-8'))
+
 def buildSetupPy(zipFile,ver,relName,packList,sList,relData):
 
     # setuptools version creates and installs a .egg file which will not work with

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -303,6 +303,8 @@ def selectFiles(cfg, key):
 
 def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
+    rogueVer = cfg['RogueVersion']:
+
     # Create conda-recipe/build.sh
     tmpTxt =  '#!/usr/bin/bash\n\n'
 
@@ -340,28 +342,31 @@ def buildCondaFiles(cfg,zipFile,ver,relName, relData):
     tmpTxt += 'requirements:\n'
 
     if 'LibDir' in relData:
-        tmpTxt += '  build:\n'
-        tmpTxt += "    - {{ compiler('c') }}\n"
-        tmpTxt += "    - {{ compiler('cxx') }}\n"
-        tmpTxt += '    - rogue\n'
-        tmpTxt += '\n'
+        tmpTxt +=  "  build:\n"
+        tmpTxt +=  "    - {{ compiler('c') }}\n"
+        tmpTxt +=  "    - {{ compiler('cxx') }}\n"
+        tmpTxt +=  "    - cmake\n"
+        tmpTxt +=  "    - make\n"
+        tmpTxt += f"    - rogue{rogueVer}\n"
+        tmpTxt += "\n"
 
-    tmpTxt += '  host:\n'
-    tmpTxt += '    - python>=3.7\n'
-    tmpTxt += '\n'
-    tmpTxt += '  run:\n'
-    tmpTxt += '    - python>=3.7\n'
-    tmpTxt += '    - rogue\n'
+    tmpTxt +=  "  host:\n"
+    tmpTxt += f"    - rogue{rogueVer}\n"
+    tmpTxt +=  "    - python>=3.7\n"
+    tmpTxt +=  "\n"
+    tmpTxt +=  "  run:\n"
+    tmpTxt +=  "    - python>=3.7\n"
+    tmpTxt += f"    - rogue{rogueVer}\n"
 
     if 'CondaDependencies' in cfg and cfg['CondaDependencies'] is not None:
         for f in cfg['CondaDependencies']:
-            tmpTxt += f'    - {f}\n'
+            tmpTxt += f"    - {f}\n"
 
-    tmpTxt += '\n'
-    tmpTxt += 'about:\n'
-    tmpTxt += '  license: SLAC Open License\n'
-    tmpTxt += '  license_file: LICENSE.txt\n'
-    tmpTxt += '\n'
+    tmpTxt += "\n"
+    tmpTxt += "about:\n"
+    tmpTxt += "  license: SLAC Open License\n"
+    tmpTxt += "  license_file: LICENSE.txt\n"
+    tmpTxt += "\n'
 
     with zipFile.open('conda-recipe/meta.yaml','w') as f:
         f.write(tmpTxt.encode('utf-8'))

--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -304,7 +304,7 @@ def selectFiles(cfg, key):
 def buildCondaFiles(cfg,zipFile,ver,relName, relData):
 
     if 'RogueVersion' in cfg:
-        rogueVer = cfg['RogueVersion']:
+        rogueVer = cfg['RogueVersion']
     else:
         rogueVer = ''
 


### PR DESCRIPTION
This PR update the firmwareRelease.py scripts to match with the latest conda formats, and using setuptools instead of the deprecated distutils. Also pip is used to install the python packages in conda.

By default the min python version is set to 3.7. This PR also allows the rogue and python version dependencies to be overridden by adding them to the CondaDependencies list:


CondaDependencies:
   - 'rogue>=v5.18'
   - 'python>=3.9'
   - surf
   - rce_gen3_fw_lib

This PR also will build python only packages as norarch.

