### PR TITLE
vivado/vcs.tcl Update

### DIFF
--- a/system_vcs.mk
+++ b/system_vcs.mk
@@ -50,7 +50,7 @@ endif
 
 # VCS elaborate options
 ifndef VCS_ELAB_OPTS
-export VCS_ELAB_OPTS = -full64 +warn=none -kdb -lca -debug_pp -t ps -licqueue -l $(SIM_OUT_DIR)/elaborate.log
+export VCS_ELAB_OPTS = -full64 -debug_acc+pp+dmptf +warn=none -kdb -lca -debug_pp -t ps -licqueue -l $(SIM_OUT_DIR)/elaborate.log
 endif
 
 # Path to VCS analyze script

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -113,7 +113,7 @@ export SIM_CARGS_VHDL = -nc -l +v2k -xlrm -kdb
 endif
 
 ifndef SIM_VCS_FLAGS
-export SIM_VCS_FLAGS = +warn=none -kdb -lca
+export SIM_VCS_FLAGS = -debug_acc+pp+dmptf +warn=none -kdb -lca
 endif
 
 ###############################################################


### PR DESCRIPTION
### Description
- Fixed the issue with Vivado 2023.1 changing sim_vcs_mx.sh format
- Cleaned up the  sim_vcs_mx.sh.tcl parsing in vcs.tcl as well
- Tested on both Vivado 2022.2 and Vivado 2023.1