### PR TITLE
Added variables for VCS script generation

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -368,7 +368,7 @@ vcs : $(SOURCE_DEPEND)
 	@cd $(OUT_DIR); vivado -mode batch -source $(RUCKUS_DIR)/vivado/vcs.tcl
 
 ###############################################################
-#### Vivado ModelSim/Questa Simulation #################################
+#### Vivado ModelSim/Questa Simulation ########################
 ###############################################################
 .PHONY : msim
 msim : $(SOURCE_DEPEND)

--- a/vivado/sources.tcl
+++ b/vivado/sources.tcl
@@ -86,6 +86,11 @@ close ${out}
 set_property top ${PROJECT} [current_fileset]
 # set_property top "glbl"     [get_filesets sim_1]
 
+# If VIVADO_PROJECT_SIM variable exist, set as sim top
+if { [info exists ::env(VIVADO_PROJECT_SIM)] } {
+    set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
+}
+
 # Init the global variable
 set ::DIR_PATH ""
 set ::DIR_LIST ""

--- a/vivado/vcs.tcl
+++ b/vivado/vcs.tcl
@@ -130,9 +130,17 @@ SourceTclFile ${VIVADO_DIR}/pre_vcs.tcl
 
 # Setup variables
 set VersionNumber [GetVcsName]
-set simLibOutDir ${VIVADO_INSTALL}/vcs-${VersionNumber}
+if { [info exists ::env(VCS_LIB_PATH)] } {
+    set simLibOutDir $::env(VCS_LIB_PATH)
+} else {
+    set simLibOutDir ${VIVADO_INSTALL}/vcs-${VersionNumber}
+}
 set simTbOutDir ${OUT_DIR}/${PROJECT}_project.sim/sim_1/behav
-set simTbFileName [get_property top [get_filesets sim_1]]
+if { [info exists ::env(VIVADO_PROJECT_SIM)] } {
+    set simTbFileName $::env(VIVADO_PROJECT_SIM)
+} else {
+    set simTbFileName [get_property top [get_filesets sim_1]]
+}
 
 # Set the compile/elaborate options
 set vloganOpt $::env(SIM_CARGS_VERILOG)


### PR DESCRIPTION
List of changes:

**vivado/vcs.tcl**
- If `VCS_LIB_PATH` variable exists, then that is PATH where the vivado compiled libraries for VCS are, otherwise use default PATH `${VIVADO_INSTALL}/vcs-${VersionNumber}`
- if `VIVADO_PROJECT_SIM` exists, then set that as simulation name, otherwise set as `[get_property top [get_filesets sim_1]]` 
(NB the variable `VIVADO_PROJECT_SIM` is used also in vivado/xsim.tcl and vivado/msim.tcl scrips)

**vivado/sources.tcl**
- if `VIVADO_PROJECT_SIM` is set, then set it as simulation top level (otherwise you would have conflict if you run directly `make vcs` after a `make clean`. This might make the change in `vivado/vcs.tcl` concerning the use of `VIVADO_PROJECT_SIM` variable useless, but since that is what is done in both xsim.tcl and msim.tcl, I would leave it as double confirmation, in case you want to modify the simulation top level after having done `make sources`.

**system_vivado.mk**
- Just a small beautify, fix of a previous PR i made