### PR TITLE
Prevent XSIM from attempting to block on non-existent run

### DIFF
--- a/vivado/xsim.tcl
+++ b/vivado/xsim.tcl
@@ -64,10 +64,6 @@ set sim_rc [catch {
    # Run simulation for time specified
    set VIVADO_PROJECT_SIM_TIME "run ${VIVADO_PROJECT_SIM_TIME}"; # set cmd
    eval ${VIVADO_PROJECT_SIM_TIME}; # run cmd
-   set src_rc [catch {
-      wait_on_run sim_1
-   } _RESULT]
-
 } _SIM_RESULT]
 
 ########################################################


### PR DESCRIPTION
The XSIM integration currently uses `wait_on_run` on a design run called `sim_1`. Since Vivado treats XSIM simulation runs as entirely separate to the design runs, `sim_1` isn't considered a run that you can call `wait_on_run` on (confirmed through `get_runs` returning only `synth_1` and `impl_1` despite being able to run a simulation run, and the `create_run` command only having options for synthesis and implementation flows).

The run command executed just prior to this line is already a blocking call, so the `wait_on_run` isn't necessary and this PR removes it.

I'm not sure if this has changed at some point in Vivado's history, but I have confirmed that at least in 2023.2 there is no design run called `sim_1`. I had a look at the recent release notes and didn't see anything relevant, but happy to put in a version condition if you're aware of if it worked in a previous version of Vivado.