### PR TITLE
Modelsim/Questa simulation script generation

### DIFF
--- a/vivado/msim.tcl
+++ b/vivado/msim.tcl
@@ -285,7 +285,7 @@ while { [eof ${in}] != 1 } {
     set line [string map ${replaceString}  ${line}]
 
     # Change the glbl.v path (Vivado 2017.2 fix)
-    set replaceString "behav/vcs/glbl.v glbl.v"
+    set replaceString "behav/[string tolower ${Simulator}]/glbl.v glbl.v"
     set line [string map ${replaceString}  ${line}]
 
     # Write to file
@@ -345,7 +345,7 @@ if { [VersionCompare 2022.1] <= 0 } {
    if { ${vList}   == "" &&
         ${vhList}  == "" &&
         ${svList}  == "" } {
-      # Remove xil_defaultlib.glbl (bug fix for Vivado compiling VCS script)
+      # Remove xil_defaultlib.glbl (bug fix for Vivado compiling Msim script)
        set line [string map { "xil_defaultlib.glbl" "" } ${line}]
    }
 
@@ -407,7 +407,7 @@ if { ${msimVcdDump} } {
         gets ${in} line
         puts ${out} ${line}
     }
-    puts ${out} "vcd file sim.vcd"
+    puts ${out} "vcd file ${simTbFileName}.vcd"
     puts ${out} "vcd add -r *"
 
     # Close the files
@@ -430,8 +430,8 @@ if { [file exists ${simTbOutDir}/[string tolower ${Simulator}]/glbl.v] == 1 } {
     exec cp -f ${simTbOutDir}/[string tolower ${Simulator}]/glbl.v ${simTbOutDir}/glbl.v
 }
 
-# Target specific VCS script
-SourceTclFile ${VIVADO_DIR}/post_vcs.tcl
+# Target specific MSIM script
+SourceTclFile ${VIVADO_DIR}/post_msim.tcl
 
 # Close the project (required for cd function)
 close_project
@@ -439,5 +439,5 @@ close_project
 # Set rogue Sim
 set rogueSimEn false
 
-# VCS Complete Message
-VcsCompleteMessage ${simTbOutDir} ${rogueSimEn}
+# MSIM Complete Message
+MsimCompleteMessage ${simTbOutDir} ${rogueSimEn}

--- a/vivado/msim.tcl
+++ b/vivado/msim.tcl
@@ -270,11 +270,11 @@ while { [eof ${in}] != 1 } {
     # Do not execute the simulation in sim_msim.sh build script
     if { [string match "*simulate.do*" ${line}] } {
         if { ${msimGui} } {
-            set line "echo \"\vsim -64 ${runOpt} -do \\\"do \{simulate.do\}\\\" -lib xil_defaultlib ${simTbFileName}_opt\" >> vsim\n"
+            set line "echo \"\vsim -64 ${runOpt} -do \\\"do \{simulate.do\}\\\" -lib xil_defaultlib ${simTbFileName}_opt\" > vsim\n"
             append line "chmod 0755 ${simTbOutDir}/simv\n"
             append line   echo \"Ready to simulate\""
         } else {
-            set line "echo \"vsim -64 -c ${runOpt} -do \\\"do \{simulate.do\}\\\" -lib ${simTbLibName} ${simTbFileName}_opt\" >> simv\n"
+            set line "echo \"vsim -64 -c ${runOpt} -do \\\"do \{simulate.do\}\\\" -lib ${simTbLibName} ${simTbFileName}_opt\" > simv\n"
             append line "chmod 0755 ${simTbOutDir}/simv\n"
             append line "echo \"Ready to simulate\""
         }

--- a/vivado/msim.tcl
+++ b/vivado/msim.tcl
@@ -190,28 +190,20 @@ foreach filePntr ${fileList} {
    }
 }
 
+# Export command export_simulation  -lib_map_path "/home/fmarini/git/BlueSurf/build/BlueSurf/BlueSurf_project.cache/compile_simlib/questa" -absolute_path -directory "/home/fmarini/git/BlueSurf/build/BlueSurf" -simulator questa  -use_ip_compiled_libs
+
+# with vcs: export_simulation  -lib_map_path "/home/fmarini/git/BlueSurf/build/BlueSurf/BlueSurf_project.cache/compile_simlib/vcs" -absolute_path -directory "/home/fmarini/git/BlueSurf/build/BlueSurf" -simulator vcs  -use_ip_compiled_libs
+
 #####################################################################################################
-## Run Questa simulation
+## Export the Simulation
 #####################################################################################################
-set errMsg "\n\n*********************************************************\n"
-set errMsg "${errMsg}Error in ${Simulator}. Check the errors in the console\n"
-   set errMsg "${errMsg}*********************************************************\n\n"
 
-set sim_rc [catch {
+# Export Xilinx & User IP Cores
+generate_target -force {simulation} [get_ips]
+export_ip_user_files -force -no_script
 
-    # Set sim properties
-    set_property top ${VIVADO_PROJECT_SIM} [get_filesets sim_1]
-    set_property top_lib xil_defaultlib [get_filesets sim_1]
+# Launch the scripts generator
+set include [get_property include_dirs   [get_filesets sim_1]]; # Verilog only
+set define  [get_property verilog_define [get_filesets sim_1]]; # Verilog only
+export_simulation -force -absolute_path -simulator questa -include ${include} -define ${define} -lib_map_path ${simLibOutDir} -directory ${simTbOutDir}/
 
-    # Launch the msim
-    launch_simulation -install_path ${MSIM_PATH}
-
-} _SIM_RESULT]
-
-########################################################
-# Check for error return code during the process
-########################################################
-if { ${sim_rc} } {
-    puts ${errMsg}
-    exit -1
-}

--- a/vivado/proc/sim_management.tcl
+++ b/vivado/proc/sim_management.tcl
@@ -78,3 +78,20 @@ proc VcsCompleteMessage {dirPath rogueSim} {
    puts "\t\$ ./simv -verdi &"
    puts "********************************************************\n\n"
 }
+
+## Print the MSIM build complete message
+proc MsimCompleteMessage {dirPath rogueSim} {
+   puts "\n\n********************************************************"
+   puts "The Modelsim/Questa simulation script has been generated."
+   puts "To compile and run the simulation:"
+   puts "\t\$ cd ${dirPath}/"
+   if { ${rogueSim} == true } {
+      if { $::env(SHELL) != "/bin/bash" } {
+         puts "\t\$ source setup_env.csh"
+      } else {
+         puts "\t\$ source setup_env.sh"
+      }
+   }
+   puts "\t\$ ./sim_msim.sh"
+   puts "********************************************************\n\n"
+}


### PR DESCRIPTION
As the `make vcs` command does, now `make msim` generates a simulation script.
This is very useful for example if you want to integrate the simulation of a ruckus project with cocotb (especially if it is a mixed language simulation, as in VCS, mixed language and cocotb do not mix well).

The process is very similar to the VCS script generation. The main difference is that the co-simulation with Rogue is not included.
Maybe I'll add that part in the future, as I currently use VCS for the rogue simulation.

So, in sysnthesis:

- Replaced the Modelsim/Questa simulation directly run in Vivado in favor of simulation script generation
- No software co-simulation support for Rogue
- Added possibility of script modification through env. variables:
    - `MSIM_PATH`: in case Modelsim/Questa not in `PATH`, this variable points to the simulator folder
    - `MSIM_LIB_PATH`: path to the simulation libraries. If not set, the default path is `${VIVADO_INSTALL}/msim-${VersionNumber}`
    - `MSIM_CARGS_VERILOG`: extra compile options for verilog
    - `MSIM_CARGS_VHDL`: extra compile options for VHDL
    - `MSIM_ELAB_FLAGS`: extra elaboration options
    - `MSIM_RUN_FLAGS`: extra simulation launch options
    - `MSIM_RUN_GUI`: run simulation with GUI (`true`/`false`)
    - `MSIM_DUMP_VCD`: dump VCD file from simulation (`true`/`false`)