### PR TITLE
Release Candidate 4.15.0

### DIFF
--- a/.github/workflows/conda_build_win.yml
+++ b/.github/workflows/conda_build_win.yml
@@ -1,0 +1,59 @@
+# ----------------------------------------------------------------------------
+# Title      : Ruckus GitHub Actions CI Script
+# ----------------------------------------------------------------------------
+# This file is part of the 'Ruckus Package'. It is subject to
+# the license terms in the LICENSE.txt file found in the top-level directory
+# of this distribution and at:
+#    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+# No part of the 'Ruckus Package', including this file, may be
+# copied, modified, propagated, or distributed except according to the terms
+# contained in the LICENSE.txt file.
+# ----------------------------------------------------------------------------
+
+name: Anaconda Build for Windows
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+    secrets:
+      CONDA_UPLOAD_TOKEN_TAG:
+        required: true
+
+jobs:
+  conda_build_win:
+    name: Anaconda Build Windows
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-latest
+    steps:
+
+      # This step checks out a copy of your repository.
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          C:\Miniconda\condabin\conda.bat activate base
+          C:\Miniconda\condabin\conda.bat install anaconda-client conda-build
+          C:\Miniconda\condabin\conda.bat update --all
+
+      - name: Get Image Information
+        id: get_image_info
+        run: |
+          echo ::set-output name=tag::`git describe --tags`
+
+      - name: Build And Upload
+        env:
+          IMAGE_VER: ${{ steps.get_image_info.outputs.tag }}
+          CONDA_UPLOAD_TOKEN_TAG: ${{ secrets.CONDA_UPLOAD_TOKEN_TAG }}
+        run: |
+          C:\Miniconda\condabin\conda.bat activate base
+          C:\Miniconda\condabin\conda.bat build software\conda-recipe --output-folder bld-dir -c conda-forge
+          C:\Miniconda\Scripts\anaconda.exe -t $env:CONDA_UPLOAD_TOKEN_TAG upload --force bld-dir\win-64\*.tar.bz2

--- a/.github/workflows/ruckus_ci.yml
+++ b/.github/workflows/ruckus_ci.yml
@@ -54,36 +54,14 @@ jobs:
           github_token: ${{ secrets.GH_TOKEN }}
           publish_dir: html
 
+# ----------------------------------------------------------------------------
+
   gen_release:
-    name: Generate Release
-    runs-on: ubuntu-20.04
     needs: [test_and_document]
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
+    uses: slaclab/ruckus/.github/workflows/gen_release.yml@main
+    with:
+      version: '1.0.0'
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-
-      - name: Get Image Information
-        id: get_image_info
-        run: |
-          echo ::set-output name=tag::`git describe --tags`
-
-      - name: Install Dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r scripts/pip_requirements.txt
-
-      - name: Gen Release
-        env:
-          TRAVIS_REPO_SLUG: ${{ github.repository }}
-          TRAVIS_TAG: ${{ steps.get_image_info.outputs.tag }}
-          GH_REPO_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          python scripts/releaseGen.py
-
+# ----------------------------------------------------------------------------

--- a/vivado/vcs.tcl
+++ b/vivado/vcs.tcl
@@ -253,7 +253,7 @@ if { ${rogueSimPath} != "" } {
    set rogueSimEn true
 
    # Check the zeromq library exists and its version
-   set err_ret [catch {exec pkg-config --exists {libzmq >= 4.2.0} --print-errors} libzmq]
+   set err_ret [catch {exec pkg-config --exists {libzmq >= 4.1.0} --print-errors} libzmq]
    if { ${libzmq} != "" } {
       puts "\n\n\n\n\n********************************************************"
       if { [string match "*Package libzmq was not found*" ${libzmq}] == 1 } {

--- a/vivado/vcs.tcl
+++ b/vivado/vcs.tcl
@@ -270,14 +270,14 @@ if { ${rogueSimPath} != "" } {
    # Create the setup environment script: C-SHELL
    set envScript [open ${simTbOutDir}/setup_env.csh  w]
    puts  ${envScript} "limit stacksize 60000"
-   set LD_LIBRARY_PATH "setenv LD_LIBRARY_PATH ${simTbOutDir}:$::env(LD_LIBRARY_PATH)"
+   set LD_LIBRARY_PATH "setenv LD_LIBRARY_PATH \${LD_LIBRARY_PATH}:${simTbOutDir}"
    puts  ${envScript} ${LD_LIBRARY_PATH}
    close ${envScript}
 
    # Create the setup environment script: S-SHELL
    set envScript [open ${simTbOutDir}/setup_env.sh  w]
    puts  ${envScript} "ulimit -S -s 60000"
-   set LD_LIBRARY_PATH "export LD_LIBRARY_PATH=$::env(LD_LIBRARY_PATH):${simTbOutDir}"
+   set LD_LIBRARY_PATH "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:${simTbOutDir}"
    puts  ${envScript} ${LD_LIBRARY_PATH}
    close ${envScript}
 


### PR DESCRIPTION
### Description
- https://github.com/slaclab/ruckus/pull/326
- [adding conda_build_win.yml](https://github.com/slaclab/ruckus/commit/e078784d9dee1d3bb2c8fb572ac07c713fa73101)
- [Reducing libzmq requirement >= 4.1.0 for RHEL8 and CENTOS7](https://github.com/slaclab/ruckus/pull/327/commits/225a710b3b932e5fb8dbb1154cee746a9c8d45a4)
- [bug fix to VCS setup_env.sh(.csh) generation to prevent picking up internal Vivado LD_LIBRARY_PATH](https://github.com/slaclab/ruckus/pull/327/commits/1282dcc6b677ce6f8fdae68e5508a006f4c7c08e)