### PR TITLE
Check if there are any ip cores in the design before trying to compile them

### DIFF
--- a/vivado/build.tcl
+++ b/vivado/build.tcl
@@ -60,7 +60,12 @@ if { [CheckSynth] != true } {
 ########################################################
 ## Check if we re-synthesis any of the IP cores
 ########################################################
-BuildIpCores
+if {[llength [get_ips]] > 0} {
+    BuildIpCores
+} else {
+    puts "No IP cores found."
+}
+
 
 ########################################################
 ## Target Pre synthesis script


### PR DESCRIPTION
If there are no IP cores in a design, vivado throws an error when command `BuildIpCores` is used.
With this commit ruckus checks whether there are any IP cores before issuing `BuildIpCores`