### PR TITLE
Update to vivado/proc.tcl

### DIFF
--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -21,3 +21,6 @@ source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/ip_management.tc
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/output_files.tcl
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/project_management.tcl
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/sim_management.tcl
+
+# Target specific proc.tcl script
+SourceTclFile $::env(VIVADO_DIR)/proc.tcl


### PR DESCRIPTION
### Description
- adding ability for custom user proc.tcl to be included with the 'submodule/ruckus/vivado/proc.tcl` loading
- Example of custom script: https://github.com/slaclab/Simple-10GbE-RUDP-KCU105-Example/blob/main/firmware/targets/Simple10GbeRudpKcu105Example/vivado/proc.tcl

![image](https://github.com/user-attachments/assets/01c62c89-3917-4684-a36a-c24baf115f6b)
