### PR TITLE
hot fix: typo in input reference

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ input.gh_username }}
+          username: ${{ inputs.gh_username }}
           password: ${{ secrets.GH_TOKEN }}
 
       # Build and push the docker image


### PR DESCRIPTION
Fix typo in input reference.

Pending successfull Rogue deployment. 