### PR TITLE
logical bug fix for vivado/messages.tcl

### DIFF
--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -198,9 +198,9 @@ if { [info exists ::env(ALLOW_MULTI_DRIVEN)] != 1 || $::env(ALLOW_MULTI_DRIVEN) 
 # Check if Un-Driven Nets are **NOT** allowed
 ########################################################
 if { [info exists ::env(ALLOW_UN_DRIVEN)] != 1 || $::env(ALLOW_UN_DRIVEN) == 0 } {
-    set_msg_config -id {Synth 8-3848} -new_severity ERROR; # SYNTH: un-driven net
+    set_msg_config -id {Synth 8-3936} -new_severity ERROR; # SYNTH: un-driven net
 } else {
-    set_msg_config -id {Synth 8-3848} -new_severity "CRITICAL WARNING"; # SYNTH: un-driven net
+    set_msg_config -id {Synth 8-3936} -new_severity "CRITICAL WARNING"; # SYNTH: un-driven net
 }
 
 ########################################################

--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -195,15 +195,6 @@ if { [info exists ::env(ALLOW_MULTI_DRIVEN)] != 1 || $::env(ALLOW_MULTI_DRIVEN) 
 }
 
 ########################################################
-# Check if Un-Driven Nets are **NOT** allowed
-########################################################
-if { [info exists ::env(ALLOW_UN_DRIVEN)] != 1 || $::env(ALLOW_UN_DRIVEN) == 0 } {
-    set_msg_config -id {Synth 8-3936} -new_severity ERROR; # SYNTH: un-driven net
-} else {
-    set_msg_config -id {Synth 8-3936} -new_severity "CRITICAL WARNING"; # SYNTH: un-driven net
-}
-
-########################################################
 # Check if inferred latch are **NOT** allowed
 ########################################################
 if { [info exists ::env(ALLOW_LATCH)] != 1 || $::env(ALLOW_LATCH) == 0 } {

--- a/vivado/messages.tcl
+++ b/vivado/messages.tcl
@@ -197,28 +197,28 @@ if { [info exists ::env(ALLOW_MULTI_DRIVEN)] != 1 || $::env(ALLOW_MULTI_DRIVEN) 
 ########################################################
 # Check if Un-Driven Nets are **NOT** allowed
 ########################################################
-if { [info exists ::env(ALLOW_UN_DRIVEN)] != 1 || $::env(ALLOW_UN_DRIVEN) == 1 } {
-    set_msg_config -id {Synth 8-3848} -new_severity "CRITICAL WARNING"; # SYNTH: un-driven net
-} else {
+if { [info exists ::env(ALLOW_UN_DRIVEN)] != 1 || $::env(ALLOW_UN_DRIVEN) == 0 } {
     set_msg_config -id {Synth 8-3848} -new_severity ERROR; # SYNTH: un-driven net
+} else {
+    set_msg_config -id {Synth 8-3848} -new_severity "CRITICAL WARNING"; # SYNTH: un-driven net
 }
 
 ########################################################
 # Check if inferred latch are **NOT** allowed
 ########################################################
-if { [info exists ::env(ALLOW_LATCH)] != 1 || $::env(ALLOW_LATCH) == 1 } {
-    set_msg_config -id {Synth 8-327} -new_severity "CRITICAL WARNING"; # SYNTH: Inferred latch
-} else {
+if { [info exists ::env(ALLOW_LATCH)] != 1 || $::env(ALLOW_LATCH) == 0 } {
     set_msg_config -id {Synth 8-327} -new_severity ERROR; # SYNTH: Inferred latch
+} else {
+    set_msg_config -id {Synth 8-327} -new_severity "CRITICAL WARNING"; # SYNTH: Inferred latch
 }
 
 ###################################################################
 # Check if "Signal not in the sensitivity list" are **NOT** allowed
 ###################################################################
-if { [info exists ::env(ALLOW_PARTIAL_SENSE_LIST)] != 1 || $::env(ALLOW_PARTIAL_SENSE_LIST) == 1 } {
-    set_msg_config -id {Synth 8-614} -new_severity "CRITICAL WARNING";# SYNTH: Signal not in the sensitivity list
-} else {
+if { [info exists ::env(ALLOW_PARTIAL_SENSE_LIST)] != 1 || $::env(ALLOW_PARTIAL_SENSE_LIST) == 0 } {
     set_msg_config -id {Synth 8-614} -new_severity ERROR;# SYNTH: Signal not in the sensitivity list
+} else {
+    set_msg_config -id {Synth 8-614} -new_severity "CRITICAL WARNING";# SYNTH: Signal not in the sensitivity list
 }
 
 ########################################################


### PR DESCRIPTION
### Description
- The previous behavior was allowing potential issue conditions that are bad design practice when the env var was not define
- This patch asserted an error message when these design practices are done and the env var associated is not defined