### PR TITLE
Added a CSIM target to HLS

### DIFF
--- a/system_vitis_unified_hls.mk
+++ b/system_vitis_unified_hls.mk
@@ -65,6 +65,14 @@ build : proj
 	@cd $(OUT_DIR); vitis -s $(RUCKUS_DIR)/vitis/hls/build.py
 
 ###############################################################
+#### Vitis HLS CSIM Mode ######################################
+###############################################################
+.PHONY : csim
+csim : proj
+	$(call ACTION_HEADER,"Vitis HLS CSIM Mode")
+	@cd $(OUT_DIR); vitis -s $(RUCKUS_DIR)/vitis/hls/build.py --csim
+
+###############################################################
 #### Vitis HLS Interactive ####################################
 ###############################################################
 .PHONY : interactive

--- a/vitis/hls/build.py
+++ b/vitis/hls/build.py
@@ -13,6 +13,13 @@ import vitis
 import os
 import shutil
 import zipfile
+import argparse
+
+parser = argparse.ArgumentParser(
+    prog="Vitis HLS build script"
+)
+parser.add_argument("-c", "--csim",default=False,action="store_true")
+args = parser.parse_args()
 
 # Project variables
 workspace = os.getenv("OUT_DIR")
@@ -31,6 +38,10 @@ hls_test_comp = client.get_component(comp_name)
 
 # Run c-simulation on the component
 hls_test_comp.run('C_SIMULATION')
+
+if args.csim:
+    vitis.dispose()
+    exit()
 
 # Run synthesis on the component
 hls_test_comp.run('SYNTHESIS')


### PR DESCRIPTION
When developing HLS IPs it is often useful to run the csim simulation several times. The infrastructure to run it is already there. This PR only exposes this functionality to the user.