### PR TITLE
Moved from Miniconda to Miniforge for useable Github CI conda package build scripts

### DIFF
--- a/.github/workflows/conda_build_lib.yml
+++ b/.github/workflows/conda_build_lib.yml
@@ -47,10 +47,10 @@ jobs:
           OS_NAME: ${{ matrix.os }}
         run: |
           cd ${HOME}
-          wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          bash miniconda.sh -b -p ${HOME}/miniconda
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          wget -O miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+          bash miniforge3.sh -b -p ${HOME}/miniforge3
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda config --set always_yes yes
           conda config --set channel_priority strict
           conda install -n base conda-libmamba-solver
@@ -70,12 +70,12 @@ jobs:
 
       - name: Build
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda build conda-recipe --output-folder bld-dir -c tidair-tag -c conda-forge
 
       - name: Upload
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           anaconda -t ${{ steps.get_image_info.outputs.token }} upload --force bld-dir/*/*.conda

--- a/.github/workflows/conda_build_proj.yml
+++ b/.github/workflows/conda_build_proj.yml
@@ -51,10 +51,10 @@ jobs:
           OS_NAME: ${{ matrix.os }}
         run: |
           cd ${HOME}
-          wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          bash miniconda.sh -b -p ${HOME}/miniconda
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          wget -O miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+          bash miniforge3.sh -b -p ${HOME}/miniforge3
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda config --set always_yes yes
           conda config --set channel_priority strict
           conda install -n base conda-libmamba-solver
@@ -101,8 +101,8 @@ jobs:
 
       - name: Build And Upload
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           cd ${HOME}/download/
           conda build --debug conda-recipe --output-folder bld-dir -c tidair-tag -c conda-forge
           anaconda -t ${{ steps.get_image_info.outputs.token }} upload bld-dir/noarch/*.conda

--- a/.github/workflows/conda_build_win.yml
+++ b/.github/workflows/conda_build_win.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          C:\Miniconda\condabin\conda.bat activate base
-          C:\Miniconda\condabin\conda.bat install anaconda-client conda-build
-          C:\Miniconda\condabin\conda.bat update --all
+          C:\miniforge3\condabin\conda.bat activate base
+          C:\miniforge3\condabin\conda.bat install anaconda-client conda-build
+          C:\miniforge3\condabin\conda.bat update --all
 
       - name: Get Image Information
         id: get_image_info
@@ -54,6 +54,6 @@ jobs:
           IMAGE_VER: ${{ steps.get_image_info.outputs.tag }}
           CONDA_UPLOAD_TOKEN_TAG: ${{ secrets.CONDA_UPLOAD_TOKEN_TAG }}
         run: |
-          C:\Miniconda\condabin\conda.bat activate base
-          C:\Miniconda\condabin\conda.bat build software\conda-recipe --output-folder bld-dir -c conda-forge
-          C:\Miniconda\Scripts\anaconda.exe -t $env:CONDA_UPLOAD_TOKEN_TAG upload --force bld-dir\win-64\*.conda
+          C:\miniforge3\condabin\conda.bat activate base
+          C:\miniforge3\condabin\conda.bat build software\conda-recipe --output-folder bld-dir -c conda-forge
+          C:\miniforge3\Scripts\anaconda.exe -t $env:CONDA_UPLOAD_TOKEN_TAG upload --force bld-dir\win-64\*.conda


### PR DESCRIPTION
### Description
- We're updating our instructions to use Miniforge instead of Miniconda, as it offers more flexible usage terms.