### PR TITLE
Release Candidate 4.18.0

### DIFF
--- a/.github/workflows/conda_build_lib.yml
+++ b/.github/workflows/conda_build_lib.yml
@@ -47,10 +47,10 @@ jobs:
           OS_NAME: ${{ matrix.os }}
         run: |
           cd ${HOME}
-          wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          bash miniconda.sh -b -p ${HOME}/miniconda
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          wget -O miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+          bash miniforge3.sh -b -p ${HOME}/miniforge3
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda config --set always_yes yes
           conda config --set channel_priority strict
           conda install -n base conda-libmamba-solver
@@ -70,12 +70,12 @@ jobs:
 
       - name: Build
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda build conda-recipe --output-folder bld-dir -c tidair-tag -c conda-forge
 
       - name: Upload
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           anaconda -t ${{ steps.get_image_info.outputs.token }} upload --force bld-dir/*/*.conda

--- a/.github/workflows/conda_build_proj.yml
+++ b/.github/workflows/conda_build_proj.yml
@@ -51,10 +51,10 @@ jobs:
           OS_NAME: ${{ matrix.os }}
         run: |
           cd ${HOME}
-          wget -O miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-          bash miniconda.sh -b -p ${HOME}/miniconda
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          wget -O miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+          bash miniforge3.sh -b -p ${HOME}/miniforge3
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           conda config --set always_yes yes
           conda config --set channel_priority strict
           conda install -n base conda-libmamba-solver
@@ -101,8 +101,8 @@ jobs:
 
       - name: Build And Upload
         run: |
-          export PATH="${HOME}/miniconda/bin:$PATH"
-          source ${HOME}/miniconda/etc/profile.d/conda.sh
+          export PATH="${HOME}/miniforge3/bin:$PATH"
+          source ${HOME}/miniforge3/etc/profile.d/conda.sh
           cd ${HOME}/download/
           conda build --debug conda-recipe --output-folder bld-dir -c tidair-tag -c conda-forge
           anaconda -t ${{ steps.get_image_info.outputs.token }} upload bld-dir/noarch/*.conda

--- a/.github/workflows/conda_build_win.yml
+++ b/.github/workflows/conda_build_win.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          C:\Miniconda\condabin\conda.bat activate base
-          C:\Miniconda\condabin\conda.bat install anaconda-client conda-build
-          C:\Miniconda\condabin\conda.bat update --all
+          C:\miniforge3\condabin\conda.bat activate base
+          C:\miniforge3\condabin\conda.bat install anaconda-client conda-build
+          C:\miniforge3\condabin\conda.bat update --all
 
       - name: Get Image Information
         id: get_image_info
@@ -54,6 +54,6 @@ jobs:
           IMAGE_VER: ${{ steps.get_image_info.outputs.tag }}
           CONDA_UPLOAD_TOKEN_TAG: ${{ secrets.CONDA_UPLOAD_TOKEN_TAG }}
         run: |
-          C:\Miniconda\condabin\conda.bat activate base
-          C:\Miniconda\condabin\conda.bat build software\conda-recipe --output-folder bld-dir -c conda-forge
-          C:\Miniconda\Scripts\anaconda.exe -t $env:CONDA_UPLOAD_TOKEN_TAG upload --force bld-dir\win-64\*.conda
+          C:\miniforge3\condabin\conda.bat activate base
+          C:\miniforge3\condabin\conda.bat build software\conda-recipe --output-folder bld-dir -c conda-forge
+          C:\miniforge3\Scripts\anaconda.exe -t $env:CONDA_UPLOAD_TOKEN_TAG upload --force bld-dir\win-64\*.conda

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -282,8 +282,6 @@ dir:
 	@test -d $(OUT_DIR)     || mkdir $(OUT_DIR)
 	@test -d $(RELEASE_DIR) || mkdir $(RELEASE_DIR)
 	@test -d $(IP_REPO)     || mkdir $(IP_REPO)
-	@cd $(OUT_DIR); rm -f firmware
-	@cd $(OUT_DIR); ln -s $(TOP_DIR) firmware
 
 ###############################################################
 #### Vivado Sources ###########################################

--- a/vivado/proc/output_files.tcl
+++ b/vivado/proc/output_files.tcl
@@ -46,18 +46,8 @@ proc CreateFpgaBit { } {
    # Copy the .ltx file (if it exists)
    CopyLtxFile
 
-   if { $::env(GEN_XSA_IMAGE) != 0 } {
-      # Check for Vivado 2019.2 (or newer)
-      if { [VersionCompare 2019.2] >= 0 } {
-         # Try to generate the .XSA file
-         set src_rc [catch { write_hw_platform -fixed -force -include_bit -file ${imagePath}.xsa } _RESULT]
-
-      # Else Vivado 2019.1 (or older)
-      } else {
-         # Try to generate the .HDF file
-         write_hwdef -force -file ${imagePath}.hdf
-      }
-   }
+   # Create the .XSA file for Vitis and Yocto(Linux)
+   CreateXsaFile
 
    # Create the MCS file (if target/vivado/promgen.tcl exists)
    CreatePromMcs
@@ -84,6 +74,9 @@ proc CreateVersalOutputs { } {
 
    # Copy the .ltx file (if it exists)
    CopyLtxFile
+
+   # Create the .XSA file for Vitis and Yocto(Linux)
+   CreateXsaFile
 }
 
 ## Create tar.gz of all cpsw files in firmware
@@ -115,5 +108,25 @@ proc CopyLtxFile { } {
       puts "Debug Probes file copied to ${imagePath}.ltx"
    } else {
       puts "No Debug Probes found"
+   }
+}
+
+## Create the .XSA file for Vitis and Yocto(Linux)
+proc CreateXsaFile { } {
+   # Get variables
+   source -quiet $::env(RUCKUS_DIR)/vivado/env_var.tcl
+   source -quiet $::env(RUCKUS_DIR)/vivado/messages.tcl
+   set imagePath "${IMAGES_DIR}/$::env(IMAGENAME)"
+   if { $::env(GEN_XSA_IMAGE) != 0 } {
+      # Check for Vivado 2019.2 (or newer)
+      if { [VersionCompare 2019.2] >= 0 } {
+         # Try to generate the .XSA file
+         set src_rc [catch { write_hw_platform -fixed -force -include_bit -file ${imagePath}.xsa } _RESULT]
+
+      # Else Vivado 2019.1 (or older)
+      } else {
+         # Try to generate the .HDF file
+         write_hwdef -force -file ${imagePath}.hdf
+      }
    }
 }


### PR DESCRIPTION
### Description
- #351 
- [adding XSA export to CreateVersalOutputs() proc](https://github.com/slaclab/ruckus/pull/352/commits/3ff357780236bf18d43b6fa84ed0f7300bbbdf27)

### Bug Fix for a recursive path
- [removing symbol link due to recursivelinking in Vivado 2025.1 + boost](https://github.com/slaclab/ruckus/pull/352/commits/12aa971396bf0425df3f21e675c190de46d8189d)
- Here's the error message when the link was there and building the AMD VEK280 design when this pop up ... 
```
Starting Logic Optimization Task

Phase 1 Initialization

Phase 1.1 Core Generation And Design Setup

Phase 1.1.1 Generate And Synthesize MIG/Advanced IO Wizard Cores
Phase 1.1.1 Generate And Synthesize MIG/Advanced IO Wizard Cores | Checksum: 162497ba9

Time (s): cpu = 00:00:03 ; elapsed = 00:04:39 . Memory (MB): peak = 5687.711 ; gain = 3.023 ; free physical = 49113 ; free virtual = 53871
Phase 1.1 Core Generation And Design Setup | Checksum: 162497ba9

Time (s): cpu = 00:00:03 ; elapsed = 00:04:39 . Memory (MB): peak = 5687.711 ; gain = 3.023 ; free physical = 49112 ; free virtual = 53870
Phase 1 Initialization | Checksum: 162497ba9

Time (s): cpu = 00:00:03 ; elapsed = 00:04:39 . Memory (MB): peak = 5687.711 ; gain = 3.023 ; free physical = 49112 ; free virtual = 53870
INFO: [Common 17-83] Releasing license: Implementation
30 Infos, 49 Warnings, 0 Critical Warnings and 1 Errors encountered.
opt_design failed
boost::filesystem::status: Too many levels of symbolic links: "/u1/ruckman/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/SimpleVek280Example/firmware/build/petalinux/xilinx-vek280-xsct-2024.2/components/yocto/layers/meta-openembedded/meta-oe/recipes-connectivity/loudmouth"
INFO: [Common 17-206] Exiting Vivado at Sun Jul 13 17:23:50 2025...
[Sun Jul 13 17:24:01 2025] impl_1 finished
ERROR: [Vivado 12-13638] Failed runs(s) : 'impl_1'
```