### PR TITLE
updating vivado/sources.tcl for reorder_files + disable_unused

### DIFF
--- a/vivado/sources.tcl
+++ b/vivado/sources.tcl
@@ -172,5 +172,11 @@ if { ${RECONFIG_CHECKPOINT} != 0 } {
    set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
 }
 
+# Auto disable the files that are not used to clean up the GUI view
+if { [VersionCompare 2020.1] >= 0 } {
+   reorder_files -fileset sources_1 -auto -disable_unused
+   reorder_files -fileset sim_1     -auto -disable_unused
+}
+
 # Close the project
 close_project


### PR DESCRIPTION
### Description
- This is a useful feature to clean up the GUI view
- It also appears to make the Vivado GUI "snapper" when I tested on 2020.1