### PR TITLE
removing the auto disable_unused feature from PR #353

### DIFF
--- a/vivado/gui.tcl
+++ b/vivado/gui.tcl
@@ -39,3 +39,9 @@ if { [get_ips] != "" } {
 if { [CheckSynth] == true } {
    set_property NEEDS_REFRESH 0 [get_runs impl_1]
 }
+
+## Auto disable the files that are not used to clean up the GUI view
+#if { [VersionCompare 2020.1] >= 0 } {
+#   reorder_files -fileset sources_1 sim_1 -auto -disable_unused
+#   reorder_files -fileset sim_1     -auto -disable_unused
+#}

--- a/vivado/sources.tcl
+++ b/vivado/sources.tcl
@@ -172,11 +172,5 @@ if { ${RECONFIG_CHECKPOINT} != 0 } {
    set_property -name {STEPS.SYNTH_DESIGN.ARGS.MORE OPTIONS} -value {-mode out_of_context} -objects [get_runs synth_1]
 }
 
-# Auto disable the files that are not used to clean up the GUI view
-if { [VersionCompare 2020.1] >= 0 } {
-   reorder_files -fileset sources_1 -auto -disable_unused
-   reorder_files -fileset sim_1     -auto -disable_unused
-}
-
 # Close the project
 close_project


### PR DESCRIPTION
### Description
- Reason: `reorder_files -fileset sources_1 sim_1 -auto -disable_unused` could disable simulation files, which breaks the sim_1 run