### PR TITLE
Update createNewRepo.py's default writeTeam & readTeam

### DIFF
--- a/scripts/createNewRepo.py
+++ b/scripts/createNewRepo.py
@@ -118,7 +118,9 @@ parser.add_argument(
     '--writeTeam',
     nargs    = '+',
     required = False,
-    default  = [ ['slaclab','tid-id-es'] ],
+    default  = [ ['slaclab','tid-id-es'],
+                 ['slaclab','tid-id-ecs'],
+               ],
     help     = 'List of write teams [org,team_name]'
 )
 
@@ -126,7 +128,8 @@ parser.add_argument(
     '--readTeam',
     nargs    = '+',
     required = False,
-    default  = None,
+    default  = [ ['slaclab','tid-id'],
+               ],
     help     = 'List of read teams'
 )
 


### PR DESCRIPTION
### Description
- Adding tid-id team to have read permission
- Adding tid-id-ecs team to have write permission