### PR TITLE
docs: documentation overhaul — theme, content, and terminology updates

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@ import subprocess
 
 project = "ruckus"
 author = "SLAC National Accelerator Laboratory"
-copyright = "2024, SLAC National Accelerator Laboratory"
+copyright = "2026, SLAC National Accelerator Laboratory"
 
 try:
     release = subprocess.check_output(
@@ -19,7 +19,8 @@ extensions = [
     "sphinx_copybutton",
 ]
 
-html_theme = "furo"
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {"titles_only": True, "navigation_depth": -1}
 html_title = "ruckus"
 html_baseurl = "https://slaclab.github.io/ruckus/"
 

--- a/docs/explanation/build_pipeline.rst
+++ b/docs/explanation/build_pipeline.rst
@@ -151,8 +151,15 @@ when interactive exploration or debugging is needed; ``make gui`` is the natural
 point for any session where direct access to the Vivado GUI is required.
 
 
-Partial Flows: SYNTH_ONLY and SYNTH_DCP
------------------------------------------
+Dynamic Function eXchange (DFX) and Partial Build Flows
+---------------------------------------------------------
+
+AMD's current terminology for partial FPGA reconfiguration is **Dynamic Function eXchange
+(DFX)**; the legacy name is *partial reconfiguration*. See AMD UG909 for the full DFX
+design flow. The partial build flows below (``SYNTH_ONLY``, ``SYNTH_DCP``) are the
+ruckus mechanisms most commonly used when working with DFX projects — the synthesized
+checkpoint (DCP) produced by ``make dcp`` serves as the static-region input for a
+subsequent DFX implementation run.
 
 Two environment variables enable partial builds:
 

--- a/docs/explanation/build_pipeline.rst
+++ b/docs/explanation/build_pipeline.rst
@@ -121,6 +121,36 @@ Key steps:
 15. ``close_project`` and exit 0.
 
 
+Interactive Builds with ``make gui``
+--------------------------------------
+
+Running ``make gui`` opens Vivado in interactive GUI mode instead of batch mode.
+Before presenting the GUI, ruckus still runs Phase 1 in full — ``sources.tcl`` assembles
+the Vivado project exactly as it would for ``make bit``. By the time Vivado's window
+appears, the project is fully assembled: all sources, constraints, IP cores, and block
+designs are registered and the IP catalog is up to date.
+
+Common use cases for ``make gui``:
+
+- **Early project exploration** — inspect the assembled source tree, fileset membership,
+  and IP configurations before committing to a full batch build.
+- **Reviewing synthesis and implementation results** — open a project where ``synth_1``
+  or ``impl_1`` has already run and examine timing reports, resource utilization, or
+  schematic views interactively.
+- **Running XSIM simulation** — launch the simulator from the Vivado GUI against the
+  assembled simulation fileset.
+- **Investigating timing closure failures** — explore the timing report, highlight
+  critical paths in the device view, and experiment with placement constraints.
+- **Reading error and warning messages** — the Vivado Messages window aggregates
+  synthesis and implementation diagnostics in a filterable view that is easier to
+  navigate than the raw log files.
+
+``make bit`` remains the preferred target for production and CI builds because it runs
+entirely in batch mode and exits with a non-zero status on any error. Use ``make gui``
+when interactive exploration or debugging is needed; ``make gui`` is the natural starting
+point for any session where direct access to the Vivado GUI is required.
+
+
 Partial Flows: SYNTH_ONLY and SYNTH_DCP
 -----------------------------------------
 

--- a/docs/explanation/output_artifacts.rst
+++ b/docs/explanation/output_artifacts.rst
@@ -35,7 +35,7 @@ The IMAGENAME Formula
      - ``20240315143022``
    * - ``USER``
      - Unix ``$USER`` environment variable at build time
-     - ``jsmith``
+     - ``smith``
    * - ``GIT_HASH_SHORT``
      - ``git rev-parse --short HEAD`` (7 characters); replaced with ``dirty`` if there are
        uncommitted changes in the working tree
@@ -46,17 +46,17 @@ A Real Example, Decoded
 
 .. code-block:: none
 
-   Simple10GbeRudpKcu105Example-0x02180000-20240315143022-jsmith-a1b2c3d.bit
+   Simple10GbeRudpKcu105Example-0x02180000-20240315143022-smith-a1b2c3d.bit
 
 Decoded: project ``Simple10GbeRudpKcu105Example``, firmware version ``0x02180000``
-(v2.18.0.0), built 2024-03-15 at 14:30:22, by user ``jsmith``, from git commit
+(v2.18.0.0), built 2024-03-15 at 14:30:22, by user ``smith``, from git commit
 ``a1b2c3d``.
 
 If there are uncommitted local changes, ``GIT_HASH_SHORT`` is replaced with ``dirty``:
 
 .. code-block:: none
 
-   Simple10GbeRudpKcu105Example-0x02180000-20240315143022-jsmith-dirty.bit
+   Simple10GbeRudpKcu105Example-0x02180000-20240315143022-smith-dirty.bit
 
 The ``dirty`` suffix acts as a deliberate traceability gate — ruckus by default refuses to
 build with uncommitted changes unless ``GIT_BYPASS=1`` is set in the project Makefile. This

--- a/docs/explanation/ruckus_tcl_model.rst
+++ b/docs/explanation/ruckus_tcl_model.rst
@@ -116,28 +116,39 @@ The call sequence when ``make bit`` is run:
 .. code-block:: none
 
    sources.tcl: set ::DIR_PATH ""; loadRuckusTcl $PROJ_DIR
-     ::DIR_PATH = firmware/targets/Simple10GbeRudpKcu105Example/
+     ::DIR_PATH [SET]   = firmware/targets/Simple10GbeRudpKcu105Example/
+
      ruckus.tcl: loadRuckusTcl $::env(TOP_DIR)/submodules/surf
-       ::DIR_PATH = firmware/submodules/surf/         <- saved, then set
+       ::DIR_PATH [SAVE]    = firmware/targets/Simple10GbeRudpKcu105Example/
+       ::DIR_PATH [SET]     = firmware/submodules/surf/
        surf/ruckus.tcl: loadSource -dir "$::DIR_PATH/hdl"
                            ^ resolves to firmware/submodules/surf/hdl/   OK
-       ::DIR_PATH = firmware/targets/Simple10GbeRudpKcu105Example/   <- restored
+       ::DIR_PATH [RESTORE] = firmware/targets/Simple10GbeRudpKcu105Example/
+
      ruckus.tcl: loadRuckusTcl $::env(TOP_DIR)/shared
-       ::DIR_PATH = firmware/shared/                  <- saved, then set
+       ::DIR_PATH [SAVE]    = firmware/targets/Simple10GbeRudpKcu105Example/
+       ::DIR_PATH [SET]     = firmware/shared/
        shared/ruckus.tcl: loadSource -dir "$::DIR_PATH/rtl"
                               ^ resolves to firmware/shared/rtl/   OK
-       ::DIR_PATH = firmware/targets/Simple10GbeRudpKcu105Example/   <- restored
+       ::DIR_PATH [RESTORE] = firmware/targets/Simple10GbeRudpKcu105Example/
+
      ruckus.tcl: loadSource -dir "$::DIR_PATH/hdl"
                     ^ resolves to firmware/targets/Simple10GbeRudpKcu105Example/hdl/   OK
 
-Each ``ruckus.tcl`` sees its own directory in ``$::DIR_PATH`` for the duration of its
-execution. The surf library's ``$::DIR_PATH/hdl`` resolves to ``firmware/submodules/surf/hdl/``;
-the shared module's ``$::DIR_PATH/rtl`` resolves to ``firmware/shared/rtl/``; the top-level
-target's ``$::DIR_PATH/hdl`` resolves to
-``firmware/targets/Simple10GbeRudpKcu105Example/hdl/``. All three are correct because
-``loadRuckusTcl`` sets and restores ``::DIR_PATH`` around each ``source`` call.
+.. note::
 
-The key invariant: at any point during the recursive load, ``$::DIR_PATH`` equals the
-directory of the ``ruckus.tcl`` that is currently running. Writing ``$::DIR_PATH/`` as a
-prefix on every path argument is not optional — it is the mechanism that makes the recursive
-loading model correct.
+   **What to notice:**
+   Every ``loadRuckusTcl`` call performs the same three-step discipline around the
+   ``source`` call it wraps:
+
+   1. **[SAVE]** — the caller's ``::DIR_PATH`` is stashed in a local variable
+      (``LOC_PATH``) before anything changes.
+   2. **[SET]** — ``::DIR_PATH`` is updated to the directory being entered,
+      so the child ``ruckus.tcl`` sees its own directory in ``$::DIR_PATH``.
+   3. **[RESTORE]** — after the child returns, ``::DIR_PATH`` is written back
+      from ``LOC_PATH``, so the caller resumes with the correct path.
+
+   The key invariant: at any point during the recursive load, ``$::DIR_PATH``
+   equals the directory of the ``ruckus.tcl`` that is currently running.
+   Writing ``$::DIR_PATH/`` as a prefix on every path argument is not optional —
+   it is the mechanism that makes the recursive loading model correct.

--- a/docs/how-to/cadence_genus.rst
+++ b/docs/how-to/cadence_genus.rst
@@ -29,6 +29,32 @@ Replace the example paths with your actual PDK installation paths.
 
    include $(TOP_DIR)/submodules/ruckus/system_cadence_genus.mk
 
+Top-Level ruckus.tcl Structure
+------------------------------
+
+Unlike the Vivado build flow (which automatically calls ``GenBuildString`` and
+``AnalyzeSrcFileLists`` internally), the Cadence Genus flow requires you to call
+these procedures explicitly in your project's top-level ``ruckus.tcl``. The
+``GenBuildString`` call generates the build-metadata VHDL package; ``AnalyzeSrcFileLists``
+passes all source files collected by prior ``loadRuckusTcl`` calls to Genus for analysis.
+
+.. code-block:: tcl
+
+   # Load RUCKUS environment and library
+   source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_PROC_TCL)
+
+   # Load ruckus library (ruckus.BuildInfoPkg.vhd only)
+   GenBuildString $::env(SYN_DIR)
+
+   # Load the surf library
+   loadRuckusTcl "$::env(TOP_DIR)/submodules/surf"
+
+   # Load the work library
+   loadRuckusTcl "$::env(TOP_DIR)/shared"
+
+   # Analyze source code loaded into ruckus for Cadence Genus
+   AnalyzeSrcFileLists
+
 Steps
 -----
 

--- a/docs/how-to/synopsys_dc.rst
+++ b/docs/how-to/synopsys_dc.rst
@@ -27,6 +27,31 @@ Replace the example paths with your actual library installation paths.
 
    include $(TOP_DIR)/submodules/ruckus/system_synopsys_dc.mk
 
+Top-Level ruckus.tcl Structure
+------------------------------
+
+Unlike the Vivado build flow, the Synopsys Design Compiler flow requires you to call
+``GenBuildString`` and ``AnalyzeSrcFileLists`` explicitly in your project's top-level
+``ruckus.tcl``. The key difference from the Cadence Genus flow is that
+``AnalyzeSrcFileLists`` is called after **each** ``loadRuckusTcl`` with a ``-vhdlLib``
+argument naming the library that was just loaded, rather than once at the end.
+
+.. code-block:: tcl
+
+   # Load RUCKUS environment and library
+   source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_PROC_TCL)
+
+   # Load the surf library
+   loadRuckusTcl "$::env(TOP_DIR)/submodules/surf"
+   AnalyzeSrcFileLists -vhdlLib "surf"
+
+   # Load ruckus library (ruckus.BuildInfoPkg.vhd only)
+   GenBuildString $::env(SYN_DIR)
+   AnalyzeSrcFileLists -vhdlLib "ruckus"
+
+   # Analyze source code loaded into ruckus for Synopsys DC
+   AnalyzeSrcFileLists -vhdlLib "work" -vhdlTop $::env(PROJECT)
+
 Steps
 -----
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 # Documentation dependencies — versions verified via pip index 2026-03-27
 sphinx==8.1.3
-furo==2025.12.19
+sphinx-rtd-theme
 myst-parser==4.0.1
 sphinx-copybutton==0.5.2
-sphinx-autodoc-typehints==3.0.1

--- a/docs/tutorial/first_vivado_build.rst
+++ b/docs/tutorial/first_vivado_build.rst
@@ -311,14 +311,14 @@ When the build succeeds, output files appear in
 .. code-block:: none
 
    images/
-   └── Simple10GbeRudpKcu105Example-0x02180000-20240315143022-jsmith-a1b2c3d.bit
+   └── Simple10GbeRudpKcu105Example-0x02180000-20240315143022-smith-a1b2c3d.bit
 
 The filename encodes:
 
 - **Project name** — ``Simple10GbeRudpKcu105Example``
 - **Firmware version** — ``0x02180000`` (from ``PRJ_VERSION`` in ``shared_version.mk``)
 - **Build timestamp** — ``20240315143022`` (UTC, format ``YYYYMMDDHHMMSS``)
-- **Username** — ``jsmith`` (the ``$USER`` shell variable at build time)
+- **Username** — ``smith`` (the ``$USER`` shell variable at build time)
 - **Git commit hash** — ``a1b2c3d`` (short hash of the HEAD commit)
 
 If git shows uncommitted changes at build time, the git hash is replaced with ``dirty``:
@@ -326,7 +326,7 @@ If git shows uncommitted changes at build time, the git hash is replaced with ``
 .. code-block:: none
 
    images/
-   └── Simple10GbeRudpKcu105Example-0x02180000-20240315143022-jsmith-dirty.bit
+   └── Simple10GbeRudpKcu105Example-0x02180000-20240315143022-smith-dirty.bit
 
 The ``dirty`` suffix is a signal that the bitstream was built from a modified working
 tree — it cannot be reproduced exactly from the git history. For reproducible builds,


### PR DESCRIPTION
## Summary

- **Theme:** Switch Sphinx theme from Furo to `sphinx_rtd_theme` to match the rogue documentation site; adds `titles_only` and `navigation_depth` options. Eliminates Furo-specific TOC errors in reference pages as a side-effect.
- **Metadata:** Update copyright year to 2026; replace `jsmith` placeholder username with `smith` across all `.rst` source files.
- **Build pipeline:** Add `make gui` interactive build section explaining use cases (exploration, synth review, XSIM, timing debug); rename "Partial Flows" section to "Dynamic Function eXchange (DFX) and Partial Build Flows" per AMD UG909 terminology.
- **Recursion diagram:** Rework the `::DIR_PATH` two-level recursion example with explicit `[SAVE]`/`[SET]`/`[RESTORE]` annotations and a "What to notice" callout.
- **ASIC how-tos:** Add "Top-Level ruckus.tcl Structure" section to both Cadence Genus and Synopsys DC how-to guides explaining the manual `GenBuildString` / `AnalyzeSrcFileLists` calls required (unlike the Vivado flow).

## Files changed

- `docs/conf.py` — theme, theme options, copyright
- `docs/requirements.txt` — furo → sphinx-rtd-theme, remove sphinx-autodoc-typehints
- `docs/explanation/build_pipeline.rst` — make gui section, DFX rename
- `docs/explanation/ruckus_tcl_model.rst` — annotated recursion diagram
- `docs/explanation/output_artifacts.rst` — jsmith → smith
- `docs/tutorial/first_vivado_build.rst` — jsmith → smith
- `docs/how-to/cadence_genus.rst` — ruckus.tcl structure section
- `docs/how-to/synopsys_dc.rst` — ruckus.tcl structure section