### PR TITLE
Update system_vivado.mk

### DIFF
--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -231,7 +231,7 @@ else \
 fi
 endef
 
-include $(TOP_DIR)/submodules/ruckus/system_shared.mk
+include $(MODULES)/ruckus/system_shared.mk
 
 .PHONY : all
 all: target


### PR DESCRIPTION
I use different folder names for submodules. This line currently prevents that due to a hardcoded submodules folder name. Since the MODULES variable can point to the same path when not explicitly defined, it can be used instead.