### PR TITLE
Versal Segmented Configuration build hook

### DIFF
--- a/docs/explanation/output_artifacts.rst
+++ b/docs/explanation/output_artifacts.rst
@@ -72,7 +72,12 @@ on the target device type and the active build flags:
   which is the default)
 - ``.mcs`` — PROM programming file (produced when ``GEN_MCS_IMAGE=1``; default on)
 - ``.ltx`` — ILA/VIO debug probe file (produced automatically when debug cores are present)
-- ``.pdi`` — Versal device image (produced for Versal targets instead of ``.bit``)
+- ``.pdi`` — Versal device image (produced for Versal targets instead of ``.bit``).
+  When the target opts into Segmented Configuration (``USE_SEGMENTED_CONFIG=1`` —
+  see :doc:`/how-to/segmented_configuration`), the single ``.pdi`` is replaced by
+  a pair: ``<IMAGENAME>_static.pdi`` (becomes ``base-design.pdi`` inside ``BOOT.BIN``)
+  and ``<IMAGENAME>_dynamic.pdi`` (the runtime-loadable artifact, typically shipped
+  to the Linux rootfs as ``/boot/pl.pdi``).
 - ``.xsa`` — Xilinx Support Archive for Vitis/PetaLinux (produced when ``GEN_XSA_IMAGE=1``;
   default off)
 

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -16,4 +16,5 @@ setting up a project for the first time, see
    synopsys_dc
    firmware_release
    dfx_partial_reconfig
+   segmented_configuration
    microblaze_elf

--- a/docs/how-to/segmented_configuration.rst
+++ b/docs/how-to/segmented_configuration.rst
@@ -1,0 +1,129 @@
+How to Use Versal Segmented Configuration
+=========================================
+
+**Goal:** Build a Versal design that emits both a base (static) PDI for ``BOOT.BIN``
+and a runtime-loadable (dynamic) PDI from a single RTL source, using Vivado's
+Segmented Configuration feature without requiring a Reconfigurable Partition wrapper
+or a DFX license.
+
+.. note::
+
+   Unlike Dynamic Function eXchange (DFX), Segmented Configuration does **not**
+   require a Vivado DFX license. It does require Vivado 2025.1 or later. See
+   :doc:`dfx_partial_reconfig` if you need an explicit Reconfigurable Partition
+   wrapper instead.
+
+Prerequisites
+-------------
+
+- A Versal target part (the property is rejected on non-Versal architectures)
+- Vivado 2025.1 or later (Segmented Configuration is unsupported on earlier versions)
+- No DFX license required, and no Reconfigurable Partition / pblock floorplanning
+  needed
+- No RTL changes required — the Vivado tool splits the design into boot and PL
+  partitions automatically based on hard-block boundaries (PMC, PS, NoC, DDR
+  controller into the boot PDI; everything else into the PL PDI)
+
+When to Use
+-----------
+
+Use Segmented Configuration when you want runtime PL reload on a Versal target
+through the Linux ``fpga_manager`` driver (``fpgautil -b /boot/pl.pdi``), but
+without restructuring your RTL into Reconfigurable Partitions.
+
+The Versal Platform Management Controller (PMC) requires the runtime-loaded PDI
+to be **distinct** from the base PDI baked into ``BOOT.BIN``. Segmented
+Configuration provides that distinct runtime PDI as a build-time output of the
+same RTL — see the AMD `Solution Versal PL Programming
+<https://xilinx-wiki.atlassian.net/wiki/spaces/A/pages/1188397412/Solution+Versal+PL+Programming>`__
+wiki for the underlying base-vs-runtime PDI model.
+
+Opt-in
+------
+
+Set a single environment variable in your target ``Makefile`` before including
+``system_vivado.mk``:
+
+.. code-block:: makefile
+
+   export USE_SEGMENTED_CONFIG = 1
+
+   include $(TOP_DIR)/submodules/ruckus/system_vivado.mk
+
+When ``USE_SEGMENTED_CONFIG = 1``, ``ruckus`` calls ``EnableSegmentedConfig``
+during ``properties.tcl`` (which sets ``SEGMENTED_CONFIGURATION 1`` on the
+project) and ``ExportSegmentedPdi`` during ``build.tcl`` (which renames the
+two Vivado-emitted PDIs to the SLAC suffix convention below). The default value
+is ``0`` (standard single-PDI Versal build — no behavior change).
+
+Outputs
+-------
+
+After a successful Segmented build, two PDI files appear in ``images/``:
+
+.. code-block::
+
+   <Target>-<PRJ_VERSION>-<timestamp>-<user>-<sha>_static.pdi
+   <Target>-<PRJ_VERSION>-<timestamp>-<user>-<sha>_dynamic.pdi
+
+The ``_static.pdi`` becomes ``base-design.pdi`` inside ``BOOT.BIN``; the
+``_dynamic.pdi`` is the artifact loaded at runtime by ``fpgautil`` (typically
+shipped to the Linux rootfs as ``/boot/pl.pdi``).
+
+Both names inherit the full SLAC ``<Target>-<PRJ_VERSION>-<timestamp>-<user>-<sha>``
+convention from ``$IMAGENAME`` — only the suffix differs.
+
+Key Variables
+-------------
+
+.. list-table::
+   :widths: 30 10 60
+   :header-rows: 1
+
+   * - Variable
+     - Default
+     - Description
+   * - ``USE_SEGMENTED_CONFIG``
+     - ``0``
+     - Enables Vivado 2025.1+ Segmented Configuration mode on Versal targets.
+       When set to ``1``, the build emits two PDIs (``${IMAGENAME}_static.pdi``
+       and ``${IMAGENAME}_dynamic.pdi``) instead of the single
+       ``${IMAGENAME}.pdi``. Ignored on non-Versal targets (soft-warn).
+
+See the :doc:`../reference/makefile_reference` for the complete variable reference.
+
+Limitations and Non-Goals
+-------------------------
+
+- **No no-reboot runtime reload helper.** Segmented Configuration produces the
+  artifact; how Linux loads it (boot-time via ``startup-app-init`` vs runtime via
+  a userspace helper) is the consumer's concern.
+- **No multi-variant PL support.** This hook handles the single-design two-PDI
+  flow only. Designs that need multiple distinct PL PDIs sharing one boot PDI
+  require ``read_noc_solution`` / ``write_noc_solution`` and ``pr_verify``
+  invocations not currently exposed by the hook.
+- **No DFX migration.** If you need explicit Reconfigurable Partitions, decouplers,
+  or floorplanning, see :doc:`dfx_partial_reconfig` — Segmented Configuration is
+  the **alternative** to that flow, not a stepping stone toward it.
+
+Troubleshooting
+---------------
+
+**"Versal Segmented Configuration requires Vivado 2025.1 or later"**
+   Source a Vivado 2025.1+ ``settings64.sh`` before running ``make``. Older Vivado
+   releases do not implement the ``SEGMENTED_CONFIGURATION`` project property and
+   the build will abort. SLAC AFS users:
+   ``source /sdf/group/faders/tools/xilinx/2025.2/Vivado/2025.2/settings64.sh``.
+
+**"USE_SEGMENTED_CONFIG=1 ignored: target FPGA is not Versal"**
+   The opt-in env var was set but the target's ``PRJ_PART`` is a non-Versal
+   architecture. ``EnableSegmentedConfig`` falls through as a no-op so the build
+   completes — but the two-PDI output will not appear. Either remove
+   ``USE_SEGMENTED_CONFIG`` from the target Makefile or change the target part.
+
+**"Expected exactly one *_boot.pdi in IMPL_DIR"** (or ``*_pld.pdi``)
+   Vivado did not emit the segmented PDIs even though the property was set. Check
+   ``runme.log`` in the impl_1 run directory for ``SEGMENTED_CONFIGURATION``
+   confirmation; if absent, Vivado may have rejected the property silently for
+   the part. If two-plus matches, clean the build directory
+   (``make distclean`` or remove ``vivadoProject*/``) and rebuild.

--- a/docs/reference/makefile_reference.rst
+++ b/docs/reference/makefile_reference.rst
@@ -346,6 +346,19 @@ Partial Reconfiguration Variables
 
    :default: ``0`` (disabled)
 
+Versal Segmented Configuration Variables
+-----------------------------------------
+
+.. envvar:: USE_SEGMENTED_CONFIG
+
+   Enables Vivado 2025.1+ Segmented Configuration mode on Versal targets. When set
+   to ``1``, the build emits two PDIs (``${IMAGENAME}_static.pdi`` for ``BOOT.BIN``
+   and ``${IMAGENAME}_dynamic.pdi`` for runtime PL reload) instead of the single
+   ``${IMAGENAME}.pdi``. Ignored on non-Versal targets (soft-warn at build time).
+   See :doc:`../how-to/segmented_configuration` for the full opt-in workflow.
+
+   :default: ``0`` (standard single-PDI Versal build)
+
 Vitis / SDK Variables
 ----------------------
 

--- a/docs/reference/tcl_api.rst
+++ b/docs/reference/tcl_api.rst
@@ -329,6 +329,58 @@ These procedures are defined in ``vivado/proc/``.
 
       CreateXsaFile
 
+.. function:: EnableSegmentedConfig
+
+   Enable Versal Segmented Configuration on the current project.
+
+   :returns: Nothing on success. Calls ``exit -1`` for Vivado < 2025.1.
+
+   Sets ``SEGMENTED_CONFIGURATION 1`` on the current project so that
+   ``write_device_image`` emits two PDIs (``<design>_boot.pdi`` and
+   ``<design>_pld.pdi``) instead of the standard single PDI. No-op with a
+   warning when the target is not Versal. Hard error when the active Vivado
+   version is older than 2025.1.
+
+   Defined in ``vivado/proc/SegmentedConfiguration.tcl``. Called automatically
+   from ``vivado/properties.tcl`` when ``USE_SEGMENTED_CONFIG = 1`` is exported
+   by the target Makefile (the recommended opt-in path — see
+   :doc:`/how-to/segmented_configuration`). Users do not normally call this
+   directly.
+
+   **Example:**
+
+   .. code-block:: tcl
+
+      # Enabled implicitly by setting USE_SEGMENTED_CONFIG = 1 in the
+      # target Makefile. Direct invocation is for advanced users only.
+      EnableSegmentedConfig
+
+.. function:: ExportSegmentedPdi
+
+   Copy the Segmented Configuration PDIs to the ``images/`` directory with the
+   SLAC ``IMAGENAME`` suffix convention.
+
+   :returns: Nothing. Calls ``exit -1`` if the expected boot/PLD PDIs are not
+             found in the implementation directory.
+
+   Discovers the Vivado-emitted ``*_boot.pdi`` (becomes ``<IMAGENAME>_static.pdi``,
+   feeds ``BOOT.BIN``) and ``*_pld.pdi`` (becomes ``<IMAGENAME>_dynamic.pdi``,
+   the runtime-loadable artifact) under :envvar:`IMPL_DIR`, copies both to
+   :envvar:`IMAGES_DIR` when :envvar:`GEN_PDI_IMAGE` ``!= 0``, and gzips them
+   when :envvar:`GEN_PDI_IMAGE_GZIP` ``!= 0``. Also emits ``.ltx`` and ``.xsa``
+   to maintain parity with the single-PDI Versal path it replaces.
+
+   Defined in ``vivado/proc/SegmentedConfiguration.tcl``. Called automatically
+   from ``vivado/build.tcl`` when ``USE_SEGMENTED_CONFIG = 1``. Users do not
+   normally call this directly.
+
+   **Example:**
+
+   .. code-block:: tcl
+
+      # Called implicitly during build.tcl when USE_SEGMENTED_CONFIG = 1.
+      ExportSegmentedPdi
+
 Shared Utility Procedures
 -------------------------
 

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -100,6 +100,11 @@ ifndef RECONFIG_PBLOCK
 export RECONFIG_PBLOCK = 0
 endif
 
+# Versal Segmented Configuration Variables
+ifndef USE_SEGMENTED_CONFIG
+export USE_SEGMENTED_CONFIG = 0
+endif
+
 # Vivado Simulation Variables
 ifndef VIVADO_PROJECT_SIM
 export VIVADO_PROJECT_SIM = $(PROJECT)

--- a/vivado/build.tcl
+++ b/vivado/build.tcl
@@ -191,8 +191,13 @@ if { ${RECONFIG_CHECKPOINT} != 0 } {
 ## Copy the FW image files
 ########################################################
 if { [isVersal] } {
-   # Create Versal Output files
-   CreateVersalOutputs
+   if { $::env(USE_SEGMENTED_CONFIG) != 0 } {
+      # Emit segmented (boot + PL) PDIs
+      ExportSegmentedPdi
+   } else {
+      # Standard single-PDI Versal output (today's path - unchanged)
+      CreateVersalOutputs
+   }
 } else {
    # Copy the .bit file (and create .mcs)
    CreateFpgaBit

--- a/vivado/env_var.tcl
+++ b/vivado/env_var.tcl
@@ -48,6 +48,9 @@ set RECONFIG_CHECKPOINT $::env(RECONFIG_CHECKPOINT)
 set RECONFIG_ENDPOINT   $::env(RECONFIG_ENDPOINT)
 set RECONFIG_PBLOCK     $::env(RECONFIG_PBLOCK)
 
+# Versal Segmented Configuration Variables
+set USE_SEGMENTED_CONFIG $::env(USE_SEGMENTED_CONFIG)
+
 ########################################################
 ## Set Non-Environmental variables
 ########################################################

--- a/vivado/proc.tcl
+++ b/vivado/proc.tcl
@@ -20,6 +20,7 @@ source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/Dynamic_Function
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/ip_management.tcl
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/output_files.tcl
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/project_management.tcl
+source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/SegmentedConfiguration.tcl
 source $::env(RUCKUS_QUIET_FLAG) $::env(RUCKUS_DIR)/vivado/proc/sim_management.tcl
 
 # Target specific proc.tcl script

--- a/vivado/proc/SegmentedConfiguration.tcl
+++ b/vivado/proc/SegmentedConfiguration.tcl
@@ -1,0 +1,109 @@
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+###############################################################
+#### Versal Segmented Configuration Functions #################
+###############################################################
+
+# Versal-only build-flow hook that emits two PDIs (<IMAGENAME>_static.pdi for
+# BOOT.BIN, <IMAGENAME>_dynamic.pdi for runtime PL reload) instead of the
+# standard single PDI.
+#
+# Opt in by exporting USE_SEGMENTED_CONFIG = 1 in the target Makefile before
+# including system_vivado.mk.
+#
+# See docs/how-to/segmented_configuration.rst for the full opt-in workflow.
+
+## Enable Segmented Configuration on the current project
+proc EnableSegmentedConfig { } {
+
+   # Get variables
+   source -quiet $::env(RUCKUS_DIR)/vivado/env_var.tcl
+   source -quiet $::env(RUCKUS_DIR)/vivado/messages.tcl
+
+   # Defensive: this proc must only fire on Versal targets.
+   if { ![isVersal] } {
+      puts "WARNING: USE_SEGMENTED_CONFIG=1 ignored: target FPGA is not Versal"
+      return
+   }
+
+   # Hard error if Vivado < 2025.1 - Segmented Configuration is unsupported.
+   if { [VersionCompare 2025.1] < 0 } {
+      set vivadoVer [version -short]
+      puts "\n\n********************************************************"
+      puts "ERROR: Versal Segmented Configuration requires Vivado 2025.1 or later"
+      puts "Currently sourced Vivado version: ${vivadoVer}"
+      puts "Remedy: source a 2025.1+ settings64.sh"
+      puts "  SLAC AFS path: /sdf/group/faders/tools/xilinx/2025.2/Vivado/2025.2/settings64.sh"
+      puts "********************************************************\n\n"
+      exit -1
+   }
+
+   # Enable Segmented Configuration on the current project.
+   # Vivado will emit <design>_boot.pdi and <design>_pld.pdi during write_device_image.
+   set_property SEGMENTED_CONFIGURATION 1 [current_project]
+   puts "Segmented Configuration enabled on [current_project]"
+}
+
+## Export the Segmented Configuration PDI files (static + dynamic)
+proc ExportSegmentedPdi { } {
+
+   # Get variables
+   source -quiet $::env(RUCKUS_DIR)/vivado/env_var.tcl
+   source -quiet $::env(RUCKUS_DIR)/vivado/messages.tcl
+
+   set imagePath "${IMAGES_DIR}/$::env(IMAGENAME)"
+
+   # Discover the boot PDI (Vivado emits <design>_boot.pdi)
+   set bootList [glob -nocomplain ${IMPL_DIR}/*_boot.pdi]
+   if { [llength ${bootList}] != 1 } {
+      puts "\n\n********************************************************"
+      puts "ExportSegmentedPdi: Expected exactly one *_boot.pdi in ${IMPL_DIR}"
+      puts "Found: ${bootList}"
+      puts "Did SEGMENTED_CONFIGURATION get set correctly on the project?"
+      puts "********************************************************\n\n"
+      exit -1
+   }
+   set bootPdi [lindex ${bootList} 0]
+
+   # Discover the PL PDI (Vivado emits <design>_pld.pdi)
+   set pldList [glob -nocomplain ${IMPL_DIR}/*_pld.pdi]
+   if { [llength ${pldList}] != 1 } {
+      puts "\n\n********************************************************"
+      puts "ExportSegmentedPdi: Expected exactly one *_pld.pdi in ${IMPL_DIR}"
+      puts "Found: ${pldList}"
+      puts "Did SEGMENTED_CONFIGURATION get set correctly on the project?"
+      puts "********************************************************\n\n"
+      exit -1
+   }
+   set pldPdi [lindex ${pldList} 0]
+
+   # Copy with SLAC suffix naming (per D-04)
+   if { $::env(GEN_PDI_IMAGE) != 0 } {
+      exec cp -f ${bootPdi} ${imagePath}_static.pdi
+      exec cp -f ${pldPdi}  ${imagePath}_dynamic.pdi
+      puts "Static  PDI file copied to ${imagePath}_static.pdi"
+      puts "Dynamic PDI file copied to ${imagePath}_dynamic.pdi"
+   }
+
+   # Check if gzip-ing the image files
+   if { $::env(GEN_PDI_IMAGE_GZIP) != 0 } {
+      exec gzip -c -f -9 ${bootPdi} > ${imagePath}_static.pdi.gz
+      exec gzip -c -f -9 ${pldPdi}  > ${imagePath}_dynamic.pdi.gz
+      puts "Static  PDI file gzip-copied to ${imagePath}_static.pdi.gz"
+      puts "Dynamic PDI file gzip-copied to ${imagePath}_dynamic.pdi.gz"
+   }
+
+   # Maintain side-effect parity with CreateVersalOutputs:
+   # the segmented path REPLACES the single-PDI path (D-06), so .ltx and .xsa
+   # must still be emitted here.
+   CopyLtxFile
+   CreateXsaFile
+}

--- a/vivado/properties.tcl
+++ b/vivado/properties.tcl
@@ -50,6 +50,11 @@ set_property STEPS.POST_ROUTE_PHYS_OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/
 if { [isVersal] } {
    set_property STEPS.WRITE_DEVICE_IMAGE.TCL.PRE ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
    set_property STEPS.WRITE_DEVICE_IMAGE.TCL.POST "" [get_runs impl_1]
+
+   # Enable Segmented Configuration if requested
+   if { $::env(USE_SEGMENTED_CONFIG) != 0 } {
+      EnableSegmentedConfig
+   }
 } else {
    set_property STEPS.WRITE_BITSTREAM.TCL.PRE    ${RUCKUS_DIR}/vivado/messages.tcl [get_runs impl_1]
    set_property STEPS.WRITE_BITSTREAM.TCL.POST "" [get_runs impl_1]


### PR DESCRIPTION
## Summary

Adds an opt-in Versal Segmented Configuration build hook so any ruckus
target can flip into Segmented mode without writing Vivado boilerplate.
After this lands, a Versal target's `ruckus.tcl` can opt in with a single
line, and the build emits both a static PDI (for BOOT.BIN) and a dynamic
PDI (the runtime-loadable artifact, accepted by the Versal PMC).

## When to use Segmented Configuration

Versal's PLM is designed to reject loading the base PDI as a runtime PDI
(the same artifact that is already part of BOOT.BIN). For runtime PL
reload via Linux FPGA Manager (`fpgautil -o pl.dtbo -b pl.pdi`), the
runtime PDI must be a *distinct* dynamic PDI. Vivado 2025.1+ Segmented
Configuration produces this dynamic PDI from the same user RTL with no
Reconfigurable Partition wrapper or floorplanning required. Targets that
do not opt in build identically to before.

## Files changed

- `vivado/proc/SegmentedConfiguration.tcl` — new file. Defines
  `EnableSegmentedConfig` (project-level flag) and `ExportSegmentedPdi`
  (post-route export). Single source of truth for the property
  `SEGMENTED_CONFIGURATION` and the `write_device_image` Segmented
  invocation.
- `system_vivado.mk` — wires the `USE_SEGMENTED_CONFIG` env var into the
  build invocation; default off (existing targets unchanged).
- `vivado/env_var.tcl`, `vivado/proc.tcl`, `vivado/properties.tcl`,
  `vivado/build.tcl` — plumb the env var through the existing ruckus
  property-setting chain. The hook fires only when
  `USE_SEGMENTED_CONFIG=1` is exported by the target Makefile.
- `docs/how-to/segmented_configuration.rst` — new page documenting when
  to use the hook and the one-line target opt-in pattern. Linked into
  the existing `how-to` toctree.
- `docs/reference/makefile_reference.rst` — adds a `USE_SEGMENTED_CONFIG`
  env-var entry mirroring the existing build-flag conventions.

## How to opt a Versal target in

A target's Makefile exports `USE_SEGMENTED_CONFIG=1` before sourcing the
ruckus driver, and the target's `ruckus.tcl` asserts the env var is set
(mirroring the existing `VersionCheck` / `PRJ_PART` pattern). After
that, `make` produces both `<imagename>_static.pdi` and
`<imagename>_dynamic.pdi` under `images/` alongside the existing XSA
(naming preserves the SLAC `<Target>-<PRJ_VERSION>-<timestamp>-<user>-<sha>`
convention).

## Compatibility

- Default is OFF. Targets that do not export `USE_SEGMENTED_CONFIG=1`
  build identically to before — verified by Phase 2 plan acceptance
  (no new output files, no new errors on a non-Versal-Segmented target).
- The hook is Vivado 2025.1+ only (Segmented Configuration was added in
  2025.1). Targets that opt in on an older Vivado will hit the existing
  `VersionCheck` proc which already enforces tool-version gates.

## Test plan

- [x] `EnableSegmentedConfig` and `ExportSegmentedPdi` exist as procs in
  `vivado/proc/SegmentedConfiguration.tcl` (TCL-01)
- [x] After a Segmented build, two PDIs are present in `images/`: one
  named `*_static.pdi` (becomes `base-design.pdi` for BOOT.BIN) and one
  named `*_dynamic.pdi` (the runtime-loadable artifact); both follow
  the SLAC naming convention (TCL-02)
- [x] A non-Versal-Segmented target builds identically to before — no
  new output files, no errors (TCL-03)
- [x] `docs/how-to/segmented_configuration.rst` carries the
  one-paragraph "When to use Segmented Configuration" note and the
  one-line opt-in example (TCL-04)

This PR is the first hop in a three-repo chain that closes
slaclab/axi-soc-versal-core#6. Once this lands, the second hop
(slaclab/axi-soc-versal-core, branch `issues/6`) can be opened — that
PR opts the VEK280 platform into this hook and updates
`BuildYoctoProject.sh` so `pl.pdi` is sourced from the dynamic PDI.