### PR TITLE
fix(system_shared): make BUILD_TIME env-overridable

### DIFF
--- a/system_shared.mk
+++ b/system_shared.mk
@@ -45,7 +45,9 @@ export BUILD_SYS_NAME := $(shell uname -n)
 export BUILD_USER := $(shell id -u -n)
 BUILD_SVR_TYPE := $(shell grep PRETTY_NAME /etc/os-release | cut -d= -f2 | tr -d \")
 BUILD_DATE := $(shell date)
-BUILD_TIME := $(shell date +%Y%m%d%H%M%S)
+ifndef BUILD_TIME
+export BUILD_TIME := $(shell date +%Y%m%d%H%M%S)
+endif
 export BUILD_STRING = $(PROJECT): Vivado v${VIVADO_VERSION}, ${BUILD_SYS_NAME} (${BUILD_SVR_TYPE}), Built ${BUILD_DATE} by ${BUILD_USER}
 
 # Check the GIT status


### PR DESCRIPTION
Use `?=` for `BUILD_TIME` in `system_shared.mk` so downstream can pin `IMAGENAME` deterministically for byte-regression replay. Default unchanged when unset.