### PR TITLE
feat(createNewRepo): add local .flake8 to new repo scaffolding

### DIFF
--- a/scripts/createNewRepo.py
+++ b/scripts/createNewRepo.py
@@ -323,6 +323,13 @@ def setupNewRepoStructure(repo):
         content = open(f'{baseDir}/.gitattributes').read(),
     )
 
+    # Add the .flake8
+    repo.create_file(
+        path    = '.flake8',
+        message = 'Adding .flake8',
+        content = open(f'{baseDir}/.flake8').read(),
+    )
+
     # Check if submodule path(s) exist
     if args.submodules is not None:
 


### PR DESCRIPTION
Adds the local `.flake8` config into newly created GitHub repos, in the same way `.gitignore` and `.gitattributes` are committed during `setupNewRepoStructure()`.

This ensures new repos ship with the standard flake8 config so their CI lint (`flake8 --count scripts/`) has the expected ruleset from the start.