### PR TITLE
Updates for Vivado 2026.1 Support

### DIFF
--- a/MicroblazeBasicCore/vitis/bit.tcl
+++ b/MicroblazeBasicCore/vitis/bit.tcl
@@ -28,11 +28,19 @@ if { [file exists ${VIVADO_DIR}/vitis.tcl] == 1 } {
    # Generate the .XSA file
    write_hw_platform -fixed -force  -include_bit -file ${OUT_DIR}/${PROJECT}.xsa
 
-   # Create the Vitis project
-   set src_rc [catch {exec xsct -interactive ${RUCKUS_DIR}/MicroblazeBasicCore/vitis/prj.tcl >@stdout } _RESULT]
+   # Build the .ELF
+   if { [VersionCompare 2026.1] >= 0 } {
+      # Vitis 2026.1 (or newer): XSCT was removed, use the Vitis Python API
+      set src_rc [catch {exec vitis -s ${RUCKUS_DIR}/MicroblazeBasicCore/vitis/build.py >@stdout } _RESULT]
 
-   # Generate .ELF
-   set src_rc [catch {exec xsct -interactive ${RUCKUS_DIR}/MicroblazeBasicCore/vitis/elf.tcl >@stdout } _RESULT]
+   } else {
+      # Vitis 2019.2 .. 2025.x: legacy XSCT flow
+      # Create the Vitis project
+      set src_rc [catch {exec xsct -interactive ${RUCKUS_DIR}/MicroblazeBasicCore/vitis/prj.tcl >@stdout } _RESULT]
+
+      # Generate .ELF
+      set src_rc [catch {exec xsct -interactive ${RUCKUS_DIR}/MicroblazeBasicCore/vitis/elf.tcl >@stdout } _RESULT]
+   }
 
    # Add .ELF to the .bit file properties
    set add_rc [catch {

--- a/MicroblazeBasicCore/vitis/build.py
+++ b/MicroblazeBasicCore/vitis/build.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+##############################################################################
+## This file is part of 'SLAC Firmware Standard Library'.
+## It is subject to the license terms in the LICENSE.txt file found in the
+## top-level directory of this distribution and at:
+##    https://confluence.slac.stanford.edu/display/ppareg/LICENSE.html.
+## No part of 'SLAC Firmware Standard Library', including this file,
+## may be copied, modified, propagated, or distributed except according to
+## the terms contained in the LICENSE.txt file.
+##############################################################################
+
+## \file vitis/build.py
+# \brief Builds the MicroBlaze .ELF using the Vitis Unified Python API.
+#        This is the Vitis 2026.1+ replacement for the XSCT-based prj.tcl/elf.tcl
+#        flow (XSCT was removed in Vitis 2026.1).
+
+import vitis
+import os
+import glob
+import shutil
+
+# Get build system variables (exported by system_vivado.mk).
+# Resolve symlinks: the generated CMakeLists.txt collects sources from BOTH
+# aux_source_directory() (which CMake stores as the real path) and
+# USER_COMPILE_SOURCES (which expands $ENV{VITIS_PRJ}). If $::env(OUT_DIR)/build
+# is a symlink, those two spellings differ and every source compiles twice
+# ("multiple definition" at link). Canonicalizing here (and re-exporting
+# VITIS_PRJ so the CMake-time expansion matches) keeps both spellings identical.
+vitis_prj = os.path.realpath(os.environ['VITIS_PRJ'])
+vitis_elf = os.environ['VITIS_ELF']
+vitis_src = os.environ['VITIS_SRC_PATH']
+out_dir   = os.path.realpath(os.environ['OUT_DIR'])
+project   = os.environ['PROJECT']
+embed_proc = os.environ['EMBED_PROC']
+os.environ['VITIS_PRJ'] = vitis_prj
+
+# VITIS_LIB is a space-separated list of library source directories
+vitis_lib = os.environ.get('VITIS_LIB', '').split()
+
+xsa_path      = os.path.join(out_dir, f'{project}.xsa')
+platform_name = f'{project}_platform'
+app_name      = 'app_0'
+domain_name   = 'microblaze'
+
+# Remove any stale Vitis workspace
+if os.path.isdir(vitis_prj):
+    shutil.rmtree(vitis_prj, ignore_errors=True)
+
+# Create a client object and set the workspace
+client = vitis.create_client()
+client.set_workspace(vitis_prj)
+
+# Create the platform from the Vivado-exported .xsa, add a standalone
+# MicroBlaze domain, and build the platform
+platform = client.create_platform_component(name=platform_name, hw_design=xsa_path)
+platform.add_domain(name=domain_name, cpu=embed_proc, os='standalone')
+platform.build()
+
+# Create an empty application component on the generated platform
+platform_xpfm = client.find_platform_in_repos(platform_name)
+app = client.create_app_component(name=app_name, platform=platform_xpfm, domain=domain_name)
+
+# Import the user sources into the application's src/ directory
+app.import_files(from_loc=vitis_src, dest_dir_in_cmp='src')
+
+# Import the library sources (e.g. surf/.../sdk/common: ssi_printf.c, printf.c) so the
+# .c files get compiled, and add each library directory as an include path so headers
+# resolve. Mirrors the legacy prj.tcl include-path + source-link behavior.
+for lib in vitis_lib:
+    app.import_files(from_loc=lib, dest_dir_in_cmp='src')
+    app.append_app_config(key='USER_INCLUDE_DIRECTORIES', values=lib)
+
+# Optimize for size (legacy used "Optimize for size (-Os)")
+app.set_app_config(key='USER_COMPILE_OPTIMIZATION_LEVEL', values='-Os')
+
+# Build the application -> produces the .ELF
+app.build()
+
+# Locate the built .ELF and copy it to the standardized location ($VITIS_ELF)
+elf_list = glob.glob(os.path.join(app.component_location, '**', f'{app_name}.elf'), recursive=True)
+if not elf_list:
+    elf_list = glob.glob(os.path.join(app.component_location, '**', '*.elf'), recursive=True)
+if not elf_list:
+    vitis.dispose()
+    raise RuntimeError(f'build.py: no .elf produced under {app.component_location}')
+
+shutil.copyfile(elf_list[0], vitis_elf)
+os.chmod(vitis_elf, 0o664)
+print(f'build.py: copied {elf_list[0]} -> {vitis_elf}')
+
+# Close the client connection and terminate the vitis server
+vitis.dispose()

--- a/system_vivado.mk
+++ b/system_vivado.mk
@@ -202,9 +202,18 @@ ifndef EMBED_PROC
 export EMBED_PROC = microblaze_0
 endif
 
+# True when VIVADO_VERSION >= 2026.1 (Vitis dropped the Eclipse GUI/XSCT for the Unified IDE)
+VIVADO_GE_2026_1 := $(shell printf '2026.1\n%s\n' "$(VIVADO_VERSION)" | sort -V 2>/dev/null | head -n1)
+
 ifneq (, $(shell which vitis 2>/dev/null))
    export EMBED_TYPE = Vitis
-   export EMBED_GUI  = vitis -workspace $(OUT_DIR)/$(VIVADO_PROJECT).vitis -vmargs -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false
+   ifeq ($(VIVADO_GE_2026_1),2026.1)
+      # Vitis 2026.1 (or newer): Unified IDE launch syntax
+      export EMBED_GUI  = vitis -w $(OUT_DIR)/$(VIVADO_PROJECT).vitis
+   else
+      # Vitis 2019.2 .. 2025.x: legacy Eclipse-based GUI
+      export EMBED_GUI  = vitis -workspace $(OUT_DIR)/$(VIVADO_PROJECT).vitis -vmargs -Dorg.eclipse.swt.internal.gtk.cairoGraphics=false
+   endif
    export EMBED_ELF  = vivado -mode batch -source $(RUCKUS_DIR)/MicroblazeBasicCore/vitis/bit.tcl
 else
    export EMBED_TYPE = SDK

--- a/vivado/proc/project_management.tcl
+++ b/vivado/proc/project_management.tcl
@@ -32,7 +32,7 @@ proc CheckVivadoVersion { } {
       return -code error
    }
    # Check if version is newer than what official been tested
-   if { [VersionCompare 2025.2.0] > 0 } {
+   if { [VersionCompare 2026.1.0] > 0 } {
       puts "\n\n\n\n\n********************************************************"
       puts "ruckus has NOT been regression tested with this Vivado $::env(VIVADO_VERSION) release yet"
       puts "https://confluence.slac.stanford.edu/x/n4-jCg"

--- a/vivado/vcs.tcl
+++ b/vivado/vcs.tcl
@@ -71,7 +71,7 @@ proc VcsVersionCheck { } {
    set retVar -1
 
    # List of supported VCS versions
-   set supported "M-2017.03 N-2017.12 O-2018.09 Q-2020.03 R-2020.12 S-2021.09 T-2022.06 V-2023.12 W-2024.09 X-2025.06"
+   set supported "M-2017.03 N-2017.12 O-2018.09 Q-2020.03 R-2020.12 S-2021.09 T-2022.06 V-2023.12 W-2024.09 X-2025.06 Y-2026.03"
 
    # Get Version Name
    set VersionNumber [GetVcsName]


### PR DESCRIPTION
### Description
- [updating Vivado project version check to 2026.1](https://github.com/slaclab/ruckus/commit/8a11607ced3011dde96a09d9f4a6b5dc75c55950)
- [MicroblazeBasicCore: build MicroBlaze ELF via Vitis Python API for 2026.1+](https://github.com/slaclab/ruckus/commit/dd5aad5a00e3e37a002fac4909393d4f095b4f63)
- [adding Y-2026.03 to list of supported VCS versions](https://github.com/slaclab/ruckus/commit/8915e06d33038142a70bf654181a78b7ded830e0)