### PR TITLE
fix(vivado): skip POWER_OPT run steps removed for Versal in 2026.1

### DIFF
--- a/vivado/proc/project_management.tcl
+++ b/vivado/proc/project_management.tcl
@@ -241,17 +241,24 @@ proc VivadoRefresh { vivadoProject } {
 
 ## Achieve a Vivado Project
 proc ArchiveProject { } {
+   ## Versal in Vivado 2026.1+ removed the POWER_OPT run steps from the impl_1 object
+   set pwrOptSupported [expr { [VersionCompare 2026.1] < 0 || [isVersal] != "true" }]
+
    ## Make a copy of the TCL configurations
    set SYNTH_PRE     [get_property {STEPS.SYNTH_DESIGN.TCL.PRE}                 [get_runs synth_1]]
    set SYNTH_POST    [get_property {STEPS.SYNTH_DESIGN.TCL.POST}                [get_runs synth_1]]
    set OPT_PRE       [get_property {STEPS.OPT_DESIGN.TCL.PRE}                   [get_runs impl_1]]
    set OPT_POST      [get_property {STEPS.OPT_DESIGN.TCL.POST}                  [get_runs impl_1]]
-   set PWR_PRE       [get_property {STEPS.POWER_OPT_DESIGN.TCL.PRE}             [get_runs impl_1]]
-   set PWR_POST      [get_property {STEPS.POWER_OPT_DESIGN.TCL.POST}            [get_runs impl_1]]
+   if { $pwrOptSupported } {
+      set PWR_PRE       [get_property {STEPS.POWER_OPT_DESIGN.TCL.PRE}             [get_runs impl_1]]
+      set PWR_POST      [get_property {STEPS.POWER_OPT_DESIGN.TCL.POST}            [get_runs impl_1]]
+   }
    set PLACE_PRE     [get_property {STEPS.PLACE_DESIGN.TCL.PRE}                 [get_runs impl_1]]
    set PLACE_POST    [get_property {STEPS.PLACE_DESIGN.TCL.POST}                [get_runs impl_1]]
-   set PWR_OPT_PRE   [get_property {STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE}  [get_runs impl_1]]
-   set PWR_OPT_POST  [get_property {STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST} [get_runs impl_1]]
+   if { $pwrOptSupported } {
+      set PWR_OPT_PRE   [get_property {STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE}  [get_runs impl_1]]
+      set PWR_OPT_POST  [get_property {STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST} [get_runs impl_1]]
+   }
    set PHYS_OPT_PRE  [get_property {STEPS.PHYS_OPT_DESIGN.TCL.PRE}              [get_runs impl_1]]
    set PHYS_OPT_POST [get_property {STEPS.PHYS_OPT_DESIGN.TCL.POST}             [get_runs impl_1]]
    set ROUTE_PRE     [get_property {STEPS.ROUTE_DESIGN.TCL.PRE}                 [get_runs impl_1]]
@@ -269,12 +276,16 @@ proc ArchiveProject { } {
    set_property STEPS.SYNTH_DESIGN.TCL.POST                "" [get_runs synth_1]
    set_property STEPS.OPT_DESIGN.TCL.PRE                   "" [get_runs impl_1]
    set_property STEPS.OPT_DESIGN.TCL.POST                  "" [get_runs impl_1]
-   set_property STEPS.POWER_OPT_DESIGN.TCL.PRE             "" [get_runs impl_1]
-   set_property STEPS.POWER_OPT_DESIGN.TCL.POST            "" [get_runs impl_1]
+   if { $pwrOptSupported } {
+      set_property STEPS.POWER_OPT_DESIGN.TCL.PRE             "" [get_runs impl_1]
+      set_property STEPS.POWER_OPT_DESIGN.TCL.POST            "" [get_runs impl_1]
+   }
    set_property STEPS.PLACE_DESIGN.TCL.PRE                 "" [get_runs impl_1]
    set_property STEPS.PLACE_DESIGN.TCL.POST                "" [get_runs impl_1]
-   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  "" [get_runs impl_1]
-   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST "" [get_runs impl_1]
+   if { $pwrOptSupported } {
+      set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  "" [get_runs impl_1]
+      set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST "" [get_runs impl_1]
+   }
    set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE              "" [get_runs impl_1]
    set_property STEPS.PHYS_OPT_DESIGN.TCL.POST             "" [get_runs impl_1]
    set_property STEPS.ROUTE_DESIGN.TCL.PRE                 "" [get_runs impl_1]
@@ -295,12 +306,16 @@ proc ArchiveProject { } {
    set_property STEPS.SYNTH_DESIGN.TCL.POST                ${SYNTH_POST}    [get_runs synth_1]
    set_property STEPS.OPT_DESIGN.TCL.PRE                   ${OPT_PRE}       [get_runs impl_1]
    set_property STEPS.OPT_DESIGN.TCL.POST                  ${OPT_POST}      [get_runs impl_1]
-   set_property STEPS.POWER_OPT_DESIGN.TCL.PRE             ${PWR_PRE}       [get_runs impl_1]
-   set_property STEPS.POWER_OPT_DESIGN.TCL.POST            ${PWR_POST}      [get_runs impl_1]
+   if { $pwrOptSupported } {
+      set_property STEPS.POWER_OPT_DESIGN.TCL.PRE             ${PWR_PRE}       [get_runs impl_1]
+      set_property STEPS.POWER_OPT_DESIGN.TCL.POST            ${PWR_POST}      [get_runs impl_1]
+   }
    set_property STEPS.PLACE_DESIGN.TCL.PRE                 ${PLACE_PRE}     [get_runs impl_1]
    set_property STEPS.PLACE_DESIGN.TCL.POST                ${PLACE_POST}    [get_runs impl_1]
-   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  ${PWR_OPT_PRE}   [get_runs impl_1]
-   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST ${PWR_OPT_POST}  [get_runs impl_1]
+   if { $pwrOptSupported } {
+      set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  ${PWR_OPT_PRE}   [get_runs impl_1]
+      set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST ${PWR_OPT_POST}  [get_runs impl_1]
+   }
    set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE              ${PHYS_OPT_PRE}  [get_runs impl_1]
    set_property STEPS.PHYS_OPT_DESIGN.TCL.POST             ${PHYS_OPT_POST} [get_runs impl_1]
    set_property STEPS.ROUTE_DESIGN.TCL.PRE                 ${ROUTE_PRE}     [get_runs impl_1]

--- a/vivado/properties.tcl
+++ b/vivado/properties.tcl
@@ -23,17 +23,22 @@ set_property STEPS.SYNTH_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/synth.tcl
 set_property STEPS.OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/opt.tcl  [get_runs impl_1]
 set_property STEPS.OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/opt.tcl [get_runs impl_1]
 
-# Setup scripts for POWER_OPT
-set_property STEPS.POWER_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/power_opt.tcl  [get_runs impl_1]
-set_property STEPS.POWER_OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/power_opt.tcl [get_runs impl_1]
+# Setup scripts for POWER_OPT and POST_PLACE_POWER_OPT
+# Note: Versal in Vivado 2026.1+ removed these run steps from the impl_1 object
+if { [VersionCompare 2026.1] < 0 || [isVersal] != true } {
+   set_property STEPS.POWER_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/power_opt.tcl  [get_runs impl_1]
+   set_property STEPS.POWER_OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/power_opt.tcl [get_runs impl_1]
+}
 
 # Setup scripts for PLACE
 set_property STEPS.PLACE_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/place.tcl  [get_runs impl_1]
 set_property STEPS.PLACE_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/place.tcl [get_runs impl_1]
 
 # Setup scripts for POST_PLACE_POWER_OPT
-set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/post_place_power_opt.tcl  [get_runs impl_1]
-set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/post_place_power_opt.tcl [get_runs impl_1]
+if { [VersionCompare 2026.1] < 0 || [isVersal] != true } {
+   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/post_place_power_opt.tcl  [get_runs impl_1]
+   set_property STEPS.POST_PLACE_POWER_OPT_DESIGN.TCL.POST ${RUCKUS_DIR}/vivado/run/post/post_place_power_opt.tcl [get_runs impl_1]
+}
 
 # Setup scripts for PHYS_OPT
 set_property STEPS.PHYS_OPT_DESIGN.TCL.PRE  ${RUCKUS_DIR}/vivado/run/pre/phys_opt.tcl  [get_runs impl_1]


### PR DESCRIPTION
## Problem

Building a **Versal** project with **Vivado 2026.1** aborts during project setup while sourcing `vivado/properties.tcl`:

```
ERROR: [Common 17-54] The object 'run' does not have a property 'STEPS.POWER_OPT_DESIGN.TCL.PRE'.
    while executing "source ${RUCKUS_DIR}/vivado/properties.tcl"
```

The same target built cleanly on 2025.2, and Kintex-7 / UltraScale / UltraScale+ targets build fine on 2026.1.

## Root cause

Vivado 2026.1 restructured the **Versal** implementation flow and removed the `POWER_OPT_DESIGN` and `POST_PLACE_POWER_OPT_DESIGN` run *steps* from the `impl_1` run object. Confirmed by querying `list_property [get_runs impl_1]` on a throwaway 2026.1 project:

| Part | `STEPS.POWER_OPT_DESIGN.TCL.PRE` present? |
|------|-------------------------------------------|
| Kintex-7 (`xc7k325t`) | ✅ |
| UltraScale (`xcku040`) | ✅ |
| UltraScale+ (`xczu7ev`) | ✅ |
| **Versal (`xcve2802`)** | ❌ |

Versal exposed these properties through 2025.2, so the cutoff is exactly **2026.1, Versal only**. `properties.tcl` set the four `STEPS.*.TCL.PRE/POST` hooks unconditionally, so the assignment threw before sources were loaded.

## Fix

Guard the power-opt step-property assignments with:

```tcl
[VersionCompare 2026.1] < 0 || [isVersal] != true
```

Behavior is byte-for-byte preserved for:
- All non-Versal architectures, every Vivado version → properties still set
- Versal on pre-2026.1 (e.g. 2025.2) → properties still set
- Versal on 2026.1+ → properties skipped (the only changed case)

These PRE/POST hooks only `SourceTclFile` optional target scripts and power optimization is off by default, so skipping them changes no build behavior — it only stops the crash.

`ArchiveProject` in `vivado/proc/project_management.tcl` references the same removed properties (latent crash on `make archive` for Versal 2026.1) and is guarded identically via a `pwrOptSupported` flag.

## Files

- `vivado/properties.tcl` — guard the four `set_property` calls (the reported crash)
- `vivado/proc/project_management.tcl` — `ArchiveProject` save/clear/restore of the same properties

## Testing

- Guard unit-tested against live Vivado 2026.1: Versal → guard `false`, skips cleanly; Kintex-7 → guard `true`, sets `POWER_OPT.PRE` as before (no regression).
- End-to-end `make` on a VEK280 (`xcve2802`) Versal target: clears the original `Common 17-54` error (`properties.tcl` sources cleanly in both `project.tcl` and `build.tcl`) and proceeds into block-design generation / synthesis.