### PR TITLE
Append GitHub Full Changelog compare URL to release notes

### DIFF
--- a/scripts/firmwareRelease.py
+++ b/scripts/firmwareRelease.py
@@ -675,6 +675,10 @@ def pushRelease(cfg, relName, relData, ver, tagAttach, prev):
 
     md += "\n\nRelease generated with SLAC ruckus releaseGen script\n"
 
+    # Append the GitHub "Full Changelog" compare link as the final line (only when a previous tag was provided)
+    if prev != "":
+        md += releaseNotes.getCompareUrl(remRepo, relOld, relNew)
+
     remRel = remRepo.create_git_release(tag=tag,name=msg, message=md, draft=False)
 
     print("\nUploading attachments ...")

--- a/scripts/releaseGen.py
+++ b/scripts/releaseGen.py
@@ -43,6 +43,7 @@ oldTag = git.Git('.').describe('--abbrev=0','--tags',newTag + '^')
 
 # Get release notes
 md = releaseNotes.getReleaseNotes(locRepo = git.Git('.'), remRepo = remRepo, oldTag = oldTag, newTag = newTag)
+md += releaseNotes.getCompareUrl(remRepo, oldTag, newTag)
 
 def releaseType(ver):
     parts = str.split(ver.replace('v', ''), '.')

--- a/scripts/releaseNotes.py
+++ b/scripts/releaseNotes.py
@@ -158,6 +158,15 @@ def getReleaseNotes(locRepo, remRepo, oldTag, newTag):
 
     return md
 
+
+def getCompareUrl(remRepo, oldTag, newTag):
+
+    # Only generate a compare link when there is an older tag to compare against
+    if not oldTag:
+        return ''
+
+    return f"\n**Full Changelog**: https://github.com/{remRepo.full_name}/compare/{oldTag}...{newTag}\n"
+
 if __name__ == "__main__":
     import os
 
@@ -201,5 +210,7 @@ if __name__ == "__main__":
         remRepo  = remRepo,
         oldTag   = oldTag,
         newTag   = newTag)
+
+    md += getCompareUrl(remRepo, oldTag, newTag)
 
     print(md)


### PR DESCRIPTION
## Summary

Adds a GitHub-style **Full Changelog** compare link to the end of the ruckus-generated release notes, matching the line GitHub's web-based "Generate release notes" button appends:

> **Full Changelog**: https://github.com/slaclab/wave8/compare/v3.3.1...v3.4.0

## Changes

- `scripts/releaseNotes.py` — new `getCompareUrl(remRepo, oldTag, newTag)` helper that builds the `**Full Changelog**: .../compare/OLD...NEW` line from `remRepo.full_name` (same URL style as the existing PR-link code). Returns an empty string when there is no older tag. `__main__` now appends it.
- `scripts/releaseGen.py` — appends the compare link after the generated notes (CI release path).
- `scripts/firmwareRelease.py` — appends the compare link as the **final** line, after the existing "Release generated with SLAC ruckus releaseGen script" footer (the `make release` path). Only emitted when a previous version was provided (`prev != ""`).

## Behavior

- The compare link is only generated when there is an older tag to compare against.
- With no previous version entered for `make release`, output is unchanged (no compare line).
- `flake8 --count scripts/` passes; all three files byte-compile cleanly.