### PR TITLE
feat(vivado): support surf simlink/vcs directory with legacy src fallback

### DIFF
--- a/vivado/vcs.tcl
+++ b/vivado/vcs.tcl
@@ -290,9 +290,13 @@ if { ${rogueSimPath} != "" } {
    puts  ${envScript} "export LD_LIBRARY_PATH=\${LD_LIBRARY_PATH}:${simTbOutDir}"
    close ${envScript}
 
-   # Find the surf/axi/simlink/src directory
+   # Find the surf/axi/simlink directory (prefer vcs/, fall back to legacy src/)
    set simTbDirName [file dirname [lindex ${rogueSimPath} 0]]
-   set simLinkDir   ${simTbDirName}/../src/
+   if { [file exists ${simTbDirName}/../vcs/] } {
+      set simLinkDir ${simTbDirName}/../vcs/
+   } else {
+      set simLinkDir ${simTbDirName}/../src/
+   }
 
    # Move the working directory to the simlink directory
    cd ${simLinkDir}


### PR DESCRIPTION
## Summary
`vivado/vcs.tcl` builds the rogue software co-simulation simlink shared library from `surf/axi/simlink/src`. surf will rename this directory to `surf/axi/simlink/vcs`. This change makes ruckus prefer `vcs/` when it exists and fall back to the legacy `src/` otherwise, so the VCS co-sim flow keeps working across the rename regardless of which surf commit a downstream project pins.

## Change
- `vivado/vcs.tcl`: resolve `simLinkDir` to `../vcs/` when that directory exists, else `../src/`. All downstream steps (`cd`, `SIMLINK_PWD`, `make`, `*.so` glob) already read `${simLinkDir}`, so no other lines change. The pattern exists nowhere else in the tree.

## Verification
- Static `tclsh` test of the if/else: resolves to `vcs/` when the directory exists, `src/` otherwise.
- End-to-end VCS co-sim build not exercised here (requires VCS + Vivado + rogue/zeromq).