### PR TITLE
fix(makefile): default RUCKUS_SIM_BACKEND for non-Vivado platforms

### DIFF
--- a/system_cadence_genus.mk
+++ b/system_cadence_genus.mk
@@ -55,6 +55,11 @@ export RUCKUS_GENUS_DIR  = $(RUCKUS_DIR)/cadence/genus
 export RUCKUS_PROC_TCL   = $(RUCKUS_GENUS_DIR)/proc.tcl
 export RUCKUS_QUIET_FLAG = -quiet
 
+# Rogue co-simulation backend for surf/axi/simlink/ruckus.tcl
+ifndef RUCKUS_SIM_BACKEND
+export RUCKUS_SIM_BACKEND = vcs
+endif
+
 # Project Build Directory
 export OUT_DIR     = $(abspath $(TOP_DIR)/build/$(PROJECT))
 export SYN_DIR     = $(OUT_DIR)/syn

--- a/system_ghdl.mk
+++ b/system_ghdl.mk
@@ -36,6 +36,11 @@ endif
 export RUCKUS_GHDL_DIR = $(RUCKUS_DIR)/ghdl
 export RUCKUS_PROC_TCL = $(RUCKUS_GHDL_DIR)/proc.tcl
 
+# Rogue co-simulation backend for surf/axi/simlink/ruckus.tcl
+ifndef RUCKUS_SIM_BACKEND
+export RUCKUS_SIM_BACKEND = ghdl
+endif
+
 # Project Build Directory
 ifndef OUT_DIR
 export OUT_DIR = $(abspath $(TOP_DIR)/build/$(PROJECT))

--- a/system_synopsys_dc.mk
+++ b/system_synopsys_dc.mk
@@ -67,6 +67,11 @@ export RUCKUS_DC_DIR     = $(RUCKUS_DIR)/synopsys/design_compiler
 export RUCKUS_PROC_TCL   = $(RUCKUS_DC_DIR)/proc.tcl
 export RUCKUS_QUIET_FLAG = -verbose
 
+# Rogue co-simulation backend for surf/axi/simlink/ruckus.tcl
+ifndef RUCKUS_SIM_BACKEND
+export RUCKUS_SIM_BACKEND = vcs
+endif
+
 ifndef PARALLEL_SYNTH
 export PARALLEL_SYNTH := $(shell cat /proc/cpuinfo | grep processor | wc -l)
 endif

--- a/system_vcs.mk
+++ b/system_vcs.mk
@@ -48,6 +48,11 @@ ifndef SIM_OUT_DIR
 export SIM_OUT_DIR = vcs_output
 endif
 
+# Rogue co-simulation backend for surf/axi/simlink/ruckus.tcl
+ifndef RUCKUS_SIM_BACKEND
+export RUCKUS_SIM_BACKEND = vcs
+endif
+
 # VCS elaborate options
 ifndef VCS_ELAB_OPTS
 export VCS_ELAB_OPTS = -full64 -debug_acc+pp+dmptf +warn=none -kdb -lca -debug_pp -t ps -licqueue -l $(SIM_OUT_DIR)/elaborate.log


### PR DESCRIPTION
## Summary

`RUCKUS_SIM_BACKEND` (added to `system_vivado.mk`) selects the Rogue co-simulation backend that `surf/axi/simlink/ruckus.tcl` uses to pick which `simlink/{ghdl,vcs,xsim}` source directory to load. The non-Vivado platform makefiles never set it, so their source loads fell back to unreliable environment sniffing (e.g. `VCS_VERSION` is set even during a Vivado xsim run).

This sets an explicit, **overridable** default (`ifndef` guarded) per platform:

| Makefile | Default |
|---|---|
| `system_cadence_genus.mk` | `vcs` |
| `system_synopsys_dc.mk` | `vcs` |
| `system_vcs.mk` | `vcs` |
| `system_ghdl.mk` | `ghdl` |

Values are lowercase to match the directory names consumed by `ruckus.tcl` (`$::DIR_PATH/${simBackend}`). Other `system_*.mk` files (`system_shared.mk`, `system_vitis_*`) are untouched.