### PR TITLE
ci(docs): manual docs rebuild trigger + pin sphinx-rtd-theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Documentation dependencies — versions verified via pip index 2026-03-27
 sphinx==8.1.3
-sphinx-rtd-theme
+sphinx-rtd-theme>=3.0  # 3.0 added Sphinx 8 support; keep in sync with sphinx pin above
 myst-parser==4.0.1
 sphinx-copybutton==0.5.2


### PR DESCRIPTION
## Summary

Follow-up hygiene fixes after restoring the GitHub Pages documentation site. The live `slaclab.github.io/ruckus` had regressed to serving the Jekyll-rendered `README.md` because the repo's Pages source was still the legacy branch build; that was corrected by switching the Pages source to **GitHub Actions** (`build_type: workflow`) so the `docs.yml` Sphinx artifact is actually published. These two code changes harden that pipeline:

- **`workflow_dispatch` trigger** on the Documentation workflow — allows manually rebuilding/republishing the docs from the Actions tab (or `gh workflow run docs.yml`) without pushing an empty commit. Useful precisely for cases like the Pages-source fix above, where the artifact needed a fresh publish.
- **Pin `sphinx-rtd-theme>=3.0`** — it was the only unpinned doc dependency. `sphinx-rtd-theme` 3.0 is the first release supporting Sphinx 8, and the repo pins `sphinx==8.1.3`; an unpinned resolve could drift onto an incompatible theme version.

## Verification

Ran the exact CI build command locally:

```
sphinx-build -b html -W --keep-going docs/ docs/_build/html
```

`build succeeded`, exit 0, no warnings-as-errors. Live site now serves the `sphinx_rtd_theme` build (verified `<title>ruckus — ruckus</title>`, RTD nav/search, `_static/css/theme.css` → 200).