### PR TITLE
fix(xsim): bind the renamed SimLink DPI shared library

### DIFF
--- a/vivado/gui.tcl
+++ b/vivado/gui.tcl
@@ -33,7 +33,7 @@ if { [RogueSimSources xsim] != "" } {
    # libzmq (see RoguePreloadLibStdCpp).
    RoguePreloadLibStdCpp
    # LD_LIBRARY_PATH parity so the interactively launched xsim subprocess
-   # finds RogueTcpDpi.so at runtime, mirroring vivado/xsim.tcl.
+   # finds libRogueSimLinkDpi.so at runtime, mirroring vivado/xsim.tcl.
    set simOutDir "${OUT_DIR}/${VIVADO_PROJECT}.sim/sim_1/behav/xsim"
    if { [info exists ::env(LD_LIBRARY_PATH)] } {
       set ::env(LD_LIBRARY_PATH) "${simOutDir}:$::env(LD_LIBRARY_PATH)"

--- a/vivado/run/pre/xsim.tcl
+++ b/vivado/run/pre/xsim.tcl
@@ -31,7 +31,7 @@ if { ${rogueSimPath} == "" } {
 }
 
 ########################################################
-## Locate the surf axi/simlink/xsim/ build directory (../xsim/ sibling of the
+## Locate the surf simlink/xsim/ build directory (../xsim/ sibling of the
 ## detected RogueTcpStream.vhd, mirroring vcs.tcl's ../vcs/ resolution). Older
 ## surf predates the xsim DPI backend (legacy axi/simlink/sim + src VHPI
 ## layout) and has no xsim/ directory: the Vivado xsim Rogue co-sim cannot run
@@ -42,18 +42,18 @@ set simTbDirName [file dirname [lindex ${rogueSimPath} 0]]
 set simLinkDir ${simTbDirName}/../xsim/
 if { ![file exists ${simLinkDir}] } {
    puts "*********************************************************************"
-   puts "ERROR: this surf has no axi/simlink/xsim/ DPI co-simulation backend."
+   puts "ERROR: this surf has no simlink/xsim/ DPI co-simulation backend."
    puts "  Rogue co-sim source found: [file normalize [lindex ${rogueSimPath} 0]]"
    puts "  The Vivado xsim (DPI-C) Rogue co-simulation requires a surf version"
-   puts "  that provides axi/simlink/xsim/. Use 'make vcs' for VCS co-simulation"
-   puts "  with this (older) surf version."
+   puts "  that provides an xsim/ directory beside the Rogue co-sim sources."
+   puts "  Use 'make vcs' for VCS co-simulation with this (older) surf version."
    puts "*********************************************************************"
    exit -1
 }
 
 ########################################################
 ## Version lock: the Rogue xsim DPI co-sim requires Vivado 2023.1+ (older xsc
-## link drivers cannot resolve the host multiarch crt/libs for RogueTcpDpi.so).
+## link drivers cannot resolve the host multiarch crt/libs for the DPI library).
 ## Sourced/checked only inside this Rogue-only path, so a non-Rogue xsim
 ## project on an older Vivado is completely unaffected. Covers both
 ## "make gui" -> Run Simulation and "make xsim", since this hook fires for both.
@@ -75,7 +75,7 @@ RogueCheckLibZmq
 set simOutDir [pwd]
 
 ########################################################
-## Build RogueTcpDpi.so via xsc (axi/simlink/xsim/Makefile)
+## Build libRogueSimLinkDpi.so via xsc (surf simlink/xsim/Makefile)
 ########################################################
 cd ${simLinkDir}
 exec make
@@ -94,12 +94,12 @@ cd $::env(PROJ_DIR)
 RoguePreloadLibStdCpp
 
 ########################################################
-## The xelab "-sv_lib RogueTcpStream" binding is intentionally NOT set here.
+## The xelab "-sv_lib libRogueSimLinkDpi" binding is intentionally NOT set here.
 ## Vivado builds elaborate.sh from xsim.elaborate.xelab.more_options at
 ## launch_simulation start -- BEFORE this compile-stage (xsim.compile.tcl.pre)
 ## hook runs -- so a set_property here never reaches the xelab command line.
 ## The binding is registered at project-generation time in vivado/sources.tcl
 ## (guarded on the xsim RogueTcpStream backend) so it persists into the .xpr
 ## and is baked into the generated elaborate.sh. This hook only builds and
-## stages RogueTcpDpi.so, which must exist before elaboration.
+## stages libRogueSimLinkDpi.so, which must exist before elaboration.
 ########################################################

--- a/vivado/sources.tcl
+++ b/vivado/sources.tcl
@@ -119,7 +119,10 @@ if { [get_files -of_objects [get_filesets {constrs_1}]] != "" } {
 # generates elaborate.sh. Setting xsim.elaborate.xelab.more_options from the
 # xsim.compile.tcl.pre hook is too late -- elaborate.sh is already generated.
 # Guarded on the xsim Rogue backends, so it is a no-op for non-Rogue
-# projects and for the GHDL/VCS simulation backends.
+# projects and for the GHDL/VCS simulation backends. The bound name must match
+# LIB in surf's simlink/xsim/Makefile minus the .so suffix (xelab appends .so
+# and adds no "lib" prefix), and the built library is staged into the xsim run
+# directory by vivado/run/pre/xsim.tcl.
 set rogueXsimSrc ""
 foreach rogueFile [RogueSimSources xsim] {
    if { [string match {*/xsim/RogueTcpStream.vhd} ${rogueFile}] ||
@@ -130,8 +133,8 @@ foreach rogueFile [RogueSimSources xsim] {
 }
 if { ${rogueXsimSrc} != "" } {
    set xelabOpt [get_property {xsim.elaborate.xelab.more_options} [get_filesets sim_1]]
-   if { [string first {-sv_lib RogueTcpDpi} ${xelabOpt}] == -1 } {
-      set_property -name {xsim.elaborate.xelab.more_options} -value "${xelabOpt} -sv_lib RogueTcpDpi" -objects [get_filesets sim_1]
+   if { [string first {-sv_lib libRogueSimLinkDpi} ${xelabOpt}] == -1 } {
+      set_property -name {xsim.elaborate.xelab.more_options} -value "${xelabOpt} -sv_lib libRogueSimLinkDpi" -objects [get_filesets sim_1]
    }
 }
 

--- a/vivado/xsim.tcl
+++ b/vivado/xsim.tcl
@@ -71,7 +71,7 @@ if { ${rogueSimPath} != "" } {
    RoguePreloadLibStdCpp
 
    # LD_LIBRARY_PATH parity so a script-launched xsim subprocess
-   # finds libRogueTcpStream.so at runtime, mirroring vcs.tcl's
+   # finds libRogueSimLinkDpi.so at runtime, mirroring vcs.tcl's
    # setup_env LD_LIBRARY_PATH prepend
    set simOutDir "${OUT_DIR}/${VIVADO_PROJECT}.sim/sim_1/behav/xsim"
    if { [info exists ::env(LD_LIBRARY_PATH)] } {


### PR DESCRIPTION
### Description

surf renamed the combined xsim DPI-C library from `RogueTcpDpi.so` to `libRogueSimLinkDpi.so` when SimLink moved to a top-level module. The hardcoded `-sv_lib RogueTcpDpi` that `vivado/sources.tcl` bakes into the `.xpr` (and therefore into the generated `elaborate.sh`) no longer matched the library that the xsim pre-compile hook builds and stages, so elaboration failed even though the `xsc` build and the staging copy both succeeded:

```
Invalid path for DPI library: <sim_dir>/RogueTcpDpi.so
ERROR: [USF-XSim-62] 'elaborate' step failed with error(s)
```

The hook itself was never at fault: it globs `*.so`, so it had correctly placed `libRogueSimLinkDpi.so` in the run directory.

### Changes

- `vivado/sources.tcl`: bind `-sv_lib libRogueSimLinkDpi`, and note that the bound name must track `LIB` in surf's `simlink/xsim/Makefile` minus the `.so` suffix (xelab appends `.so` and adds no `lib` prefix).
- `vivado/run/pre/xsim.tcl`, `vivado/gui.tcl`, `vivado/xsim.tcl`: comment and error-text only. Refresh the stale `RogueTcpDpi.so` / `libRogueTcpStream.so` / `axi/simlink/xsim/` references. The "older surf" error message is reworded to be layout neutral, since it only fires for a surf that predates the move.

### Compatibility

The old `RogueTcpDpi` name never shipped in a surf tag or on surf's `main`. The xsim DPI backend exists only on the `cosim-xsim` and `simlink-alignment` branches, so no released surf regresses.

VCS is unaffected: its library is resolved by the `FOREIGN` attribute inside surf's own VHDL (`vhpi:RogueSimLinkVhpi:...`), and `vivado/vcs.tcl` globs `*.so` rather than naming it.

### Testing

`make clean; make xsim` on `Simple10GbeRudpKcu105Example` with Vivado 2026.1 and surf `simlink-alignment`:

```
xelab ... -sv_lib libRogueSimLinkDpi
Built simulation snapshot Simple10GbeRudpKcu105ExampleTb_behav
RogueTcpMemory: Listening on ports 10000 & 10001
RogueTcpStream: Listening on ports 10002 & 10003
```

Elaboration passes and both DPI adapters bind and open their ZMQ sockets. The repository CI checks (trailing whitespace and tabs over `*.{tcl,py,sh}`, `compileall` and `flake8` on `scripts/`) were run locally and pass.