### PR TITLE
fix(vivado): harden file dedup, sim_1 removal, and stale xelab options

### DIFF
--- a/vivado/proc/code_loading.tcl
+++ b/vivado/proc/code_loading.tcl
@@ -55,6 +55,23 @@ proc loadRuckusTcl { filePath {flags ""} } {
    set ::DIR_LIST "$::DIR_LIST ${filePath}"
 }
 
+## Check whether a file is already in the project, comparing the resolved path
+## rather than the literal string. A project can be generated from one spelling
+## of a path and later re-generated from another (for example when the repository
+## is reached through a symlinked home directory), and a plain string test misses
+## that case, letting add_files insert a second entry for the same physical file.
+## In VHDL that surfaces later as a duplicate design unit. The query is scoped by
+## base name so it stays cheap: normally zero or one candidate.
+proc _fileInProject { path } {
+   set norm [file normalize ${path}]
+   foreach f [get_files -quiet [file tail ${path}]] {
+      if { [file normalize ${f}] eq ${norm} } {
+         return 1
+      }
+   }
+   return 0
+}
+
 ## Function to load RTL files
 proc loadSource args {
    set options {
@@ -104,7 +121,7 @@ proc loadSource args {
               ${fileExt} eq {.edif}||
               ${fileExt} eq {.dcp} } {
             # Check if file doesn't exist in project
-            if { [get_files -quiet $params(path)] == "" } {
+            if { ![_fileInProject $params(path)] } {
                # Add the RTL Files
                set src_rc [catch {add_files -fileset ${fileset} $params(path)} _RESULT]
                if {$src_rc} {
@@ -158,7 +175,7 @@ proc loadSource args {
          if { ${list} != "" } {
             foreach pntr ${list} {
                # Check if file doesn't exist in project
-               if { [get_files -quiet ${pntr}] == "" } {
+               if { ![_fileInProject ${pntr}] } {
                   # Add the RTL Files
                   set src_rc [catch {add_files -fileset ${fileset} ${pntr}} _RESULT]
                   if {$src_rc} {
@@ -521,7 +538,7 @@ proc loadConstraints args {
          if { ${fileExt} eq {.xdc} ||
               ${fileExt} eq {.tcl} } {
             # Check if file doesn't exist in project
-            if { [get_files -quiet $params(path)] == "" } {
+            if { ![_fileInProject $params(path)] } {
                # Add the constraint Files
                add_files -fileset constrs_1 $params(path)
             }
@@ -551,7 +568,7 @@ proc loadConstraints args {
             # Load all the constraint files
             foreach pntr ${list} {
                # Check if file doesn't exist in project
-               if { [get_files -quiet ${pntr}] == "" } {
+               if { ![_fileInProject ${pntr}] } {
                   # Add the RTL Files
                   add_files -fileset constrs_1 ${pntr}
                }

--- a/vivado/proc/project_management.tcl
+++ b/vivado/proc/project_management.tcl
@@ -337,7 +337,16 @@ proc SetSynthOutOfContext { } {
 
 ## Remove unused code
 proc RemoveUnsuedCode { } {
-   update_compile_order -quiet -fileset sources_1
-   update_compile_order -quiet -fileset sim_1
-   remove_files [get_files -filter {IS_AUTO_DISABLED}]
+   # Work one fileset at a time. remove_files defaults to the current source
+   # fileset, so a single blanket call cannot delete an auto-disabled file that
+   # lives in sim_1, and without -quiet that mismatch aborts the build. Query
+   # inside the loop and take sources_1 first, so a file that sim_1 merely
+   # inherits is already gone by the time sim_1 is examined.
+   foreach fileset {sources_1 sim_1} {
+      update_compile_order -quiet -fileset ${fileset}
+      set unused [get_files -quiet -of_objects [get_filesets ${fileset}] -filter {IS_AUTO_DISABLED}]
+      if { [llength ${unused}] > 0 } {
+         remove_files -fileset ${fileset} ${unused}
+      }
+   }
 }

--- a/vivado/sources.tcl
+++ b/vivado/sources.tcl
@@ -136,6 +136,17 @@ if { ${rogueXsimSrc} != "" } {
    if { [string first {-sv_lib libRogueSimLinkDpi} ${xelabOpt}] == -1 } {
       set_property -name {xsim.elaborate.xelab.more_options} -value "${xelabOpt} -sv_lib libRogueSimLinkDpi" -objects [get_filesets sim_1]
    }
+} else {
+   # Drop a token left behind by an earlier generation of this project that did
+   # use the xsim backend. The project persists across make targets, so without
+   # this an xsim-then-vcs (or xsim-then-ghdl) switch leaves xelab asking for a
+   # DPI library that is no longer part of the build. -quiet because the property
+   # only exists on the Vivado versions that take the xsim.* naming.
+   set xelabOpt [get_property -quiet {xsim.elaborate.xelab.more_options} [get_filesets sim_1]]
+   if { [string first {-sv_lib libRogueSimLinkDpi} ${xelabOpt}] != -1 } {
+      regsub -all {\s+} [string map {{-sv_lib libRogueSimLinkDpi} {}} ${xelabOpt}] { } xelabOpt
+      set_property -name {xsim.elaborate.xelab.more_options} -value [string trim ${xelabOpt}] -objects [get_filesets sim_1]
+   }
 }
 
 # Check if we can upgrade IP cores


### PR DESCRIPTION
Three latent defects in the same family as a duplicate design unit failure hit
while switching a persistent Vivado project between Rogue co-simulation
backends (`make bit` / `gui` / `xsim` / `vcs`). None of them is the direct cause
of that failure, which lives in surf's `simlink/ruckus.tcl`, but each can
produce the same class of breakage on its own.

## 1. `loadSource` / `loadConstraints` duplicate-add guard

Both procs tested project membership with a literal string compare:

```tcl
if { [get_files -quiet ${pntr}] == "" } {
```

Vivado stores fileset paths relative to `$PPRDIR` and reports them without
resolving symlinks. If a project is generated from one spelling of a path and
later re-generated from another, the guard misses and `add_files` inserts a
second entry for the same physical file. For VHDL that surfaces later as
`[filemgmt 20-1318] Duplicate Design Unit`.

Verified in Vivado 2024.1 against a real project: a file added as
`/sdf/home/<user>/.../RogueTcpStream.vhd` is not found by
`get_files` under its `/sdf/group/.../RogueTcpStream.vhd` spelling (returns
empty), while the new `_fileInProject` helper returns 1 for both spellings and
0 for a same-basename file in a different directory.

The helper scopes its query by base name, so it normally examines zero or one
candidate and adds no measurable cost. All four call sites are updated
(`loadSource` `-path` and `-dir`, `loadConstraints` `-path` and `-dir`).

Note this deliberately does not canonicalize the path handed to `add_files`.
Doing so would rewrite every existing project's stored spelling and double-add
on the first re-generation after the upgrade.

## 2. `RemoveUnsuedCode` removed from the wrong fileset

```tcl
remove_files [get_files -filter {IS_AUTO_DISABLED}]
```

`remove_files` defaults to the current source fileset, so this could not delete
an auto-disabled file living in `sim_1`, and with no `-quiet` that mismatch
aborts the build. Now removes per fileset, taking `sources_1` first so a file
that `sim_1` merely inherits via `SOURCE_SET` is already gone by the time
`sim_1` is examined.

Dormant in practice because `REMOVE_UNUSED_CODE` defaults to `0`.

## 3. Stale `-sv_lib libRogueSimLinkDpi` in the xelab options

`sources.tcl` only ever *added* the token. Because the project persists across
make targets, switching off the xsim backend to vcs or ghdl left xelab asking
for a DPI library that is no longer built. Now stripped when no xsim Rogue
source is present.

The existing add branch is untouched; this is purely an added `else`. The
`get_property` in the new branch uses `-quiet` because the `xsim.*` property
naming only exists on the Vivado versions that take it (`project.tcl` uses
`xelab.*` for 2014.2 and older).

## Testing

- `ruckus_ci.yml` checks run locally and clean: trailing whitespace and tabs
  over `*.tcl,*.py,*.sh`, `python -m compileall -f scripts/`,
  `flake8 --count scripts/` (0 findings).
- All three edited files pass a Tcl `info complete` parse check.
- `_fileInProject` exercised in Vivado 2024.1 batch mode against a real
  project for the both-spellings and different-directory cases described above.
- Token-strip logic unit tested for the only-token, token-among-others,
  no-token, and empty-string inputs.
- Downstream sanity: surf `make analysis` (GHDL flow) passes and
  `pytest tests/simlink` is 99 passed / 8 skipped. The GHDL flow sources
  `ghdl/proc.tcl`, which pulls only `shared/proc.tcl`, so none of these
  `vivado/` changes affect it.

Not yet run: a full Vivado `make bit` / `gui` / `vcs` matrix on a real target.

Draft pending review of the companion surf change to `simlink/ruckus.tcl`.
